### PR TITLE
Fix analytics dashboard Average Monthly Cost calculation

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -161,8 +161,8 @@
         </div>
         
         <div class="text-center p-4 bg-green-50 rounded-lg">
-            <p class="text-2xl font-bold text-success">${{printf "%.2f" (div .Stats.TotalAnnualSpend 12)}}</p>
-            <p class="text-sm text-gray-600">Average Monthly Cost</p>
+            <p class="text-2xl font-bold text-success">${{printf "%.2f" .Stats.TotalMonthlySpend}}</p>
+            <p class="text-sm text-gray-600">Total Monthly Cost</p>
         </div>
         
         <div class="text-center p-4 bg-purple-50 rounded-lg">


### PR DESCRIPTION
- Changed 'Average Monthly Cost' to 'Total Monthly Cost' to avoid duplication
- Fixed calculation to show total monthly spend instead of annual/12
- Keeps 'Average Cost per Subscription' for per-subscription average