### PR TITLE
Update Docker documentation for GitHub Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A self-hosted subscription management application built with Go and HTMX. Track 
 
 ## 🚀 Quick Start
 
+SubTrackr is available as a multi-platform Docker image supporting both AMD64 and ARM64 architectures (including Apple Silicon).
+
 ### Option 1: Docker Compose (Recommended)
 
 1. **Create docker-compose.yml**:
@@ -37,7 +39,7 @@ version: '3.8'
 
 services:
   subtrackr:
-    image: bscott/subtrackr:latest
+    image: ghcr.io/bscott/subtrackr:latest
     container_name: subtrackr
     ports:
       - "8080:8080"
@@ -65,7 +67,7 @@ docker run -d \
   -p 8080:8080 \
   -v $(pwd)/data:/app/data \
   -e GIN_MODE=release \
-  bscott/subtrackr:latest
+  ghcr.io/bscott/subtrackr:latest
 ```
 
 ### Option 3: Build from Source
@@ -146,7 +148,7 @@ docker-compose up -d --build
    - Apply
 
 2. **Manual Docker Template**:
-   - Repository: `bscott/subtrackr:latest`
+   - Repository: `ghcr.io/bscott/subtrackr:latest`
    - Port: `8080:8080`
    - Path: `/app/data` → `/mnt/user/appdata/subtrackr`
 


### PR DESCRIPTION
## Summary
- Update all Docker image references from Docker Hub to GitHub Container Registry (ghcr.io)
- Add information about multi-platform support (AMD64 and ARM64)
- Ensure users know the images work on Apple Silicon

## Changes
- Updated Docker pull/run commands to use `ghcr.io/bscott/subtrackr:latest`
- Added note about multi-platform architecture support in Quick Start section
- Fixed all image references throughout the README

## Test Plan
- [x] Verified all Docker image paths are updated
- [x] Confirmed multi-platform builds are working in CI
- [x] Documentation is clear and accurate