### PR TITLE
Fix Docker tagging to use full semantic versions only

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,8 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'Dockerfile'
+      - 'templates/**'
+      - 'web/**'
       - '.github/workflows/docker-publish.yml'
   pull_request:
     branches: [ main ]
@@ -17,7 +19,10 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'Dockerfile'
+      - 'templates/**'
+      - 'web/**'
       - '.github/workflows/docker-publish.yml'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -61,8 +66,6 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
Simplifies Docker image tagging to only generate full semantic version tags like `v0.2.0`, removing confusing partial version tags.

## Changes Made
### Docker Tag Simplification
- ✅ Remove `{{major}}` and `{{major}}.{{minor}}` patterns  
- ✅ Keep only `{{version}}` pattern for full semantic versions
- ✅ Maintain `latest` tag for main branch
- ✅ Result: Clean tags like `ghcr.io/bscott/subtrackr:v0.2.0`

### CI Trigger Improvements
- ✅ Add `templates/**` and `web/**` to trigger paths
- ✅ Add `workflow_dispatch` for manual builds
- ✅ Build Docker images when UI changes are made

## Before vs After
**Before:** `ghcr.io/bscott/subtrackr:0` ❌  
**After:** `ghcr.io/bscott/subtrackr:v0.2.0` ✅

This ensures clear, unambiguous version tags for production deployments.