### PR TITLE
Hotfix: Remove YAML anchors (not supported by GitHub Actions)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,23 +1,27 @@
 name: Build and Publish Docker Image
 
-# Define path filters to avoid duplication
-x-path-filters: &path-filters
-  - '**.go'
-  - 'go.mod'
-  - 'go.sum'
-  - 'Dockerfile'
-  - 'templates/**'
-  - 'web/**'
-  - '.github/workflows/docker-publish.yml'
-
 on:
   push:
     branches: [ main ]
     tags: [ 'v*' ]
-    paths: *path-filters
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - 'templates/**'
+      - 'web/**'
+      - '.github/workflows/docker-publish.yml'
   pull_request:
     branches: [ main ]
-    paths: *path-filters
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - 'templates/**'
+      - 'web/**'
+      - '.github/workflows/docker-publish.yml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## 🚨 Hotfix for Workflow Error

GitHub Actions doesn't support YAML anchors, causing workflow validation errors:
```
Anchors are not currently supported. Remove the anchor 'path-filters'
```

## Changes
- ✅ Remove YAML anchor syntax (`x-path-filters: &path-filters`)
- ✅ Revert to explicit path duplication (unfortunately necessary)
- ✅ Keep all other improvements: workflow_dispatch, clean semver tagging, expanded paths

## Keeps These Working Features
- ✅ Full semantic version tagging (`v0.2.0`)
- ✅ Templates and web paths in triggers
- ✅ Manual workflow dispatch
- ✅ Docker build includes static assets

This is a critical fix to restore CI functionality.