### PR TITLE
Fix Docker template paths - preserve directory structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ WORKDIR /app
 COPY --from=builder /app/subtrackr .
 
 # Copy templates and static assets
-COPY templates/ web/ ./
+COPY templates/ ./templates/
+COPY web/ ./web/
 
 # Expose port
 EXPOSE 8080


### PR DESCRIPTION
## 🐛 Critical Docker Fix

Fixes the Docker container panic when starting:
```
panic: html/template: pattern matches no files: templates/*
```

## Root Cause
The Dockerfile was using:
```dockerfile
COPY templates/ web/ ./
```

This flattens both directories into the root, so there's no `templates/` directory for Gin to find.

## Solution
Changed to separate COPY commands:
```dockerfile
COPY templates/ ./templates/
COPY web/ ./web/
```

This preserves the proper directory structure that the Go application expects.

## Test
After this fix, the Docker container should start properly and:
- ✅ Find templates in `/app/templates/`
- ✅ Serve static assets from `/app/web/static/`
- ✅ Display logo correctly
- ✅ No more template panic

This is a critical fix for Docker deployments.