### PR TITLE
v0.4.1 - Bug fixes and version display improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# Variables
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS := -X 'subtrackr/internal/version.GitCommit=$(GIT_COMMIT)'
+
+# Default target
+.PHONY: all
+all: build
+
+# Build the application
+.PHONY: build
+build:
+	go build -ldflags "$(LDFLAGS)" -o subtrackr cmd/server/main.go
+
+# Run the application
+.PHONY: run
+run: build
+	./subtrackr
+
+# Clean build artifacts
+.PHONY: clean
+clean:
+	rm -f subtrackr
+
+# Development mode with live reload (requires air)
+.PHONY: dev
+dev:
+	air
+
+# Run tests
+.PHONY: test
+test:
+	go test ./...
+
+# Run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+# Run go fmt
+.PHONY: fmt
+fmt:
+	go fmt ./...
+
+# Build for multiple platforms
+.PHONY: build-all
+build-all:
+	GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/subtrackr-darwin-amd64 cmd/server/main.go
+	GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/subtrackr-darwin-arm64 cmd/server/main.go
+	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/subtrackr-linux-amd64 cmd/server/main.go
+	GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/subtrackr-linux-arm64 cmd/server/main.go
+	GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/subtrackr-windows-amd64.exe cmd/server/main.go
+
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  make build    - Build the application with git commit SHA"
+	@echo "  make run      - Build and run the application"
+	@echo "  make clean    - Remove build artifacts"
+	@echo "  make test     - Run tests"
+	@echo "  make vet      - Run go vet"
+	@echo "  make fmt      - Format code"
+	@echo "  make build-all - Build for multiple platforms"
+	@echo "  make help     - Show this help message"

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"subtrackr/internal/models"
 	"subtrackr/internal/service"
+	"subtrackr/internal/version"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -96,6 +97,7 @@ func (h *SubscriptionHandler) Settings(c *gin.Context) {
 		"RenewalReminders": h.settingsService.GetBoolSettingWithDefault("renewal_reminders", false),
 		"HighCostAlerts":   h.settingsService.GetBoolSettingWithDefault("high_cost_alerts", true),
 		"ReminderDays":     h.settingsService.GetIntSettingWithDefault("reminder_days", 7),
+		"Version":          version.GetVersion(),
 	})
 }
 
@@ -235,6 +237,25 @@ func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 	if costStr := c.PostForm("cost"); costStr != "" {
 		if cost, err := strconv.ParseFloat(costStr, 64); err == nil {
 			subscription.Cost = cost
+		}
+	}
+
+	// Parse dates
+	if startDateStr := c.PostForm("start_date"); startDateStr != "" {
+		if startDate, err := time.Parse("2006-01-02", startDateStr); err == nil {
+			subscription.StartDate = &startDate
+		}
+	}
+
+	if renewalDateStr := c.PostForm("renewal_date"); renewalDateStr != "" {
+		if renewalDate, err := time.Parse("2006-01-02", renewalDateStr); err == nil {
+			subscription.RenewalDate = &renewalDate
+		}
+	}
+
+	if cancellationDateStr := c.PostForm("cancellation_date"); cancellationDateStr != "" {
+		if cancellationDate, err := time.Parse("2006-01-02", cancellationDateStr); err == nil {
+			subscription.CancellationDate = &cancellationDate
 		}
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,16 @@
+package version
+
+var (
+	// GitCommit is the git commit SHA that will be set at build time
+	GitCommit = "unknown"
+	// Version is the semantic version (if needed)
+	Version = "dev"
+)
+
+// GetVersion returns the current version string
+func GetVersion() string {
+	if GitCommit != "unknown" && GitCommit != "" {
+		return GitCommit
+	}
+	return Version
+}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -350,7 +350,7 @@
                 <div class="bg-gray-50 rounded-lg p-4">
                     <div class="flex items-center justify-between mb-2">
                         <span class="text-sm font-medium text-gray-700">Version</span>
-                        <span class="text-sm text-gray-600">1.0.0</span>
+                        <span class="text-sm text-gray-600">{{.Version}}</span>
                     </div>
                     <div class="flex items-center justify-between mb-2">
                         <span class="text-sm font-medium text-gray-700">Build</span>


### PR DESCRIPTION
## Summary
- Fixed issue #35: Subscription updates now properly save all fields including dates
- Added dynamic version display showing git commit SHA on settings page
- Added Makefile for consistent builds with version injection

## Changes
- Fixed `UpdateSubscription` handler to parse date fields (start_date, renewal_date, cancellation_date)
- Created version package for build-time version management
- Updated settings page to display dynamic version from git commit SHA
- Added Makefile with build targets for development and production

## Testing
- Tested subscription update functionality - all fields now save correctly
- Verified version displays git commit SHA on settings page
- Build process tested with Makefile

Fixes #35