### PR TITLE
Fixed api returning html instead of json

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -254,7 +254,7 @@ func setupRoutes(router *gin.Engine, handler *handlers.SubscriptionHandler, sett
 	v1.Use(middleware.APIKeyAuth(settingsService))
 	{
 		// Subscription endpoints
-		v1.GET("/subscriptions", handler.GetSubscriptions)
+		v1.GET("/subscriptions", handler.GetSubscriptionsAPI)
 		v1.POST("/subscriptions", handler.CreateSubscription)
 		v1.GET("/subscriptions/:id", handler.GetSubscription)
 		v1.PUT("/subscriptions/:id", handler.UpdateSubscription)

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -121,6 +121,17 @@ func (h *SubscriptionHandler) GetSubscriptions(c *gin.Context) {
 	})
 }
 
+// GetSubscriptionsAPI returns subscriptions as JSON for API calls
+func (h *SubscriptionHandler) GetSubscriptionsAPI(c *gin.Context) {
+	subscriptions, err := h.service.GetAll()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, subscriptions)
+}
+
 // CreateSubscription handles creating a new subscription
 func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 	var subscription models.Subscription


### PR DESCRIPTION
The /api/v1/subscriptions endpoint was incorrectly returning HTML content instead of JSON data, causing API parsing errors.

Both web and API routes were using the same handler method designed for HTML responses.

Created a separate GetSubscriptionsAPI handler that returns JSON data, while keeping the web route unchanged.