### PR TITLE
fix: Add TLS/SSL support for SMTP configuration and improve UI feedback

### DIFF
--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -24,107 +25,154 @@ func NewSettingsHandler(service *service.SettingsService) *SettingsHandler {
 // SaveSMTPSettings saves SMTP configuration
 func (h *SettingsHandler) SaveSMTPSettings(c *gin.Context) {
 	var config models.SMTPConfig
-	
+
 	// Parse form data
 	config.Host = c.PostForm("smtp_host")
 	config.Username = c.PostForm("smtp_username")
 	config.Password = c.PostForm("smtp_password")
 	config.From = c.PostForm("smtp_from")
 	config.FromName = c.PostForm("smtp_from_name")
-	
+
 	// Parse port
 	if portStr := c.PostForm("smtp_port"); portStr != "" {
 		if port, err := strconv.Atoi(portStr); err == nil {
 			config.Port = port
 		}
 	}
-	
+
 	// Validate required fields
 	if config.Host == "" || config.Port == 0 || config.Username == "" || config.Password == "" || config.From == "" {
 		c.HTML(http.StatusBadRequest, "smtp-message.html", gin.H{
 			"Error": "All SMTP fields are required",
-			"Type": "error",
+			"Type":  "error",
 		})
 		return
 	}
-	
+
 	// Save configuration
 	err := h.service.SaveSMTPConfig(&config)
 	if err != nil {
 		c.HTML(http.StatusInternalServerError, "smtp-message.html", gin.H{
 			"Error": err.Error(),
-			"Type": "error",
+			"Type":  "error",
 		})
 		return
 	}
-	
+
 	c.HTML(http.StatusOK, "smtp-message.html", gin.H{
 		"Message": "SMTP settings saved successfully",
-		"Type": "success",
+		"Type":    "success",
 	})
 }
 
-// TestSMTPConnection tests SMTP configuration
+// TestSMTPConnection tests SMTP configuration with TLS/SSL support
 func (h *SettingsHandler) TestSMTPConnection(c *gin.Context) {
 	var config models.SMTPConfig
-	
+
 	// Parse form data
 	config.Host = c.PostForm("smtp_host")
 	config.Username = c.PostForm("smtp_username")
 	config.Password = c.PostForm("smtp_password")
 	config.From = c.PostForm("smtp_from")
 	config.FromName = c.PostForm("smtp_from_name")
-	
+
 	// Parse port
 	if portStr := c.PostForm("smtp_port"); portStr != "" {
 		if port, err := strconv.Atoi(portStr); err == nil {
 			config.Port = port
 		}
 	}
-	
+
 	// Validate
 	if config.Host == "" || config.Port == 0 || config.Username == "" || config.Password == "" {
 		c.HTML(http.StatusBadRequest, "smtp-message.html", gin.H{
 			"Error": "All SMTP fields are required for testing",
-			"Type": "error",
+			"Type":  "error",
 		})
 		return
 	}
-	
-	// Test connection
-	auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
+
+	// Test connection with TLS/SSL support
 	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
-	
-	// Try to connect
-	client, err := smtp.Dial(addr)
-	if err != nil {
-		c.HTML(http.StatusBadRequest, "smtp-message.html", gin.H{
-			"Error": fmt.Sprintf("Failed to connect: %v", err),
-			"Type": "error",
-		})
-		return
+	auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
+
+	// Determine if this is an implicit TLS port (SMTPS)
+	isSSLPort := config.Port == 465 || config.Port == 8465 || config.Port == 443
+
+	var client *smtp.Client
+	var err error
+
+	if isSSLPort {
+		// Use implicit TLS (direct SSL connection)
+		tlsConfig := &tls.Config{
+			ServerName: config.Host,
+		}
+
+		conn, err := tls.Dial("tcp", addr, tlsConfig)
+		if err != nil {
+			c.HTML(http.StatusBadRequest, "smtp-message.html", gin.H{
+				"Error": fmt.Sprintf("Failed to connect via SSL: %v", err),
+				"Type":  "error",
+			})
+			return
+		}
+
+		client, err = smtp.NewClient(conn, config.Host)
+		if err != nil {
+			conn.Close()
+			c.HTML(http.StatusBadRequest, "smtp-message.html", gin.H{
+				"Error": fmt.Sprintf("Failed to create SMTP client: %v", err),
+				"Type":  "error",
+			})
+			return
+		}
+	} else {
+		// Use STARTTLS (opportunistic TLS)
+		client, err = smtp.Dial(addr)
+		if err != nil {
+			c.HTML(http.StatusBadRequest, "smtp-message.html", gin.H{
+				"Error": fmt.Sprintf("Failed to connect: %v", err),
+				"Type":  "error",
+			})
+			return
+		}
+
+		// Upgrade to TLS
+		tlsConfig := &tls.Config{
+			ServerName: config.Host,
+		}
+
+		if err = client.StartTLS(tlsConfig); err != nil {
+			client.Close()
+			c.HTML(http.StatusBadRequest, "smtp-message.html", gin.H{
+				"Error": fmt.Sprintf("Failed to start TLS: %v", err),
+				"Type":  "error",
+			})
+			return
+		}
 	}
+
 	defer client.Close()
-	
+
 	// Try to authenticate
 	if err = client.Auth(auth); err != nil {
 		c.HTML(http.StatusBadRequest, "smtp-message.html", gin.H{
 			"Error": fmt.Sprintf("Authentication failed: %v", err),
-			"Type": "error",
+			"Type":  "error",
 		})
 		return
 	}
-	
+
 	c.HTML(http.StatusOK, "smtp-message.html", gin.H{
 		"Message": "SMTP connection test successful!",
-		"Type": "success",
+		"Type":    "success",
 	})
 }
 
 // UpdateNotificationSetting updates a notification preference
 func (h *SettingsHandler) UpdateNotificationSetting(c *gin.Context) {
 	setting := c.Param("setting")
-	
+
 	switch setting {
 	case "renewal":
 		current, _ := h.service.GetBoolSetting("renewal_reminders", false)
@@ -134,7 +182,7 @@ func (h *SettingsHandler) UpdateNotificationSetting(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"enabled": !current})
-		
+
 	case "highcost":
 		current, _ := h.service.GetBoolSetting("high_cost_alerts", true)
 		err := h.service.SetBoolSetting("high_cost_alerts", !current)
@@ -143,7 +191,7 @@ func (h *SettingsHandler) UpdateNotificationSetting(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"enabled": !current})
-		
+
 	case "days":
 		daysStr := c.PostForm("reminder_days")
 		if days, err := strconv.Atoi(daysStr); err == nil && days > 0 && days <= 30 {
@@ -156,7 +204,7 @@ func (h *SettingsHandler) UpdateNotificationSetting(c *gin.Context) {
 		} else {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid days value"})
 		}
-		
+
 	default:
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Unknown setting"})
 	}
@@ -169,7 +217,7 @@ func (h *SettingsHandler) GetNotificationSettings(c *gin.Context) {
 		HighCostAlerts:   h.service.GetBoolSettingWithDefault("high_cost_alerts", true),
 		ReminderDays:     h.service.GetIntSettingWithDefault("reminder_days", 7),
 	}
-	
+
 	c.JSON(http.StatusOK, settings)
 }
 
@@ -180,12 +228,12 @@ func (h *SettingsHandler) GetSMTPConfig(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"configured": false})
 		return
 	}
-	
+
 	// Don't send the password
 	config.Password = ""
 	c.JSON(http.StatusOK, gin.H{
 		"configured": true,
-		"config": config,
+		"config":     config,
 	})
 }
 
@@ -198,14 +246,14 @@ func (h *SettingsHandler) ListAPIKeys(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	// Don't send the actual key values for existing keys
 	for i := range keys {
 		if !keys[i].IsNew {
 			keys[i].Key = ""
 		}
 	}
-	
+
 	c.HTML(http.StatusOK, "api-keys-list.html", gin.H{
 		"Keys": keys,
 	})
@@ -220,7 +268,7 @@ func (h *SettingsHandler) CreateAPIKey(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	// Generate a secure random API key
 	keyBytes := make([]byte, 32)
 	if _, err := rand.Read(keyBytes); err != nil {
@@ -229,9 +277,9 @@ func (h *SettingsHandler) CreateAPIKey(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	apiKey := "sk_" + hex.EncodeToString(keyBytes)
-	
+
 	// Save the API key
 	newKey, err := h.service.CreateAPIKey(name, apiKey)
 	if err != nil {
@@ -240,7 +288,7 @@ func (h *SettingsHandler) CreateAPIKey(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	// Get all keys including the new one
 	keys, err := h.service.GetAllAPIKeys()
 	if err != nil {
@@ -249,7 +297,7 @@ func (h *SettingsHandler) CreateAPIKey(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	// Mark the new key and include its value
 	for i := range keys {
 		if keys[i].ID == newKey.ID {
@@ -259,7 +307,7 @@ func (h *SettingsHandler) CreateAPIKey(c *gin.Context) {
 			keys[i].Key = ""
 		}
 	}
-	
+
 	c.HTML(http.StatusOK, "api-keys-list.html", gin.H{
 		"Keys": keys,
 	})
@@ -275,7 +323,7 @@ func (h *SettingsHandler) DeleteAPIKey(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	err = h.service.DeleteAPIKey(uint(id))
 	if err != nil {
 		c.HTML(http.StatusInternalServerError, "api-keys-list.html", gin.H{
@@ -283,7 +331,7 @@ func (h *SettingsHandler) DeleteAPIKey(c *gin.Context) {
 		})
 		return
 	}
-	
+
 	// Return updated list
 	h.ListAPIKeys(c)
 }
@@ -291,29 +339,29 @@ func (h *SettingsHandler) DeleteAPIKey(c *gin.Context) {
 // UpdateCurrency updates the currency preference
 func (h *SettingsHandler) UpdateCurrency(c *gin.Context) {
 	currency := c.PostForm("currency")
-	
+
 	err := h.service.SetCurrency(currency)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	
+
 	c.JSON(http.StatusOK, gin.H{
 		"currency": currency,
-		"symbol": h.service.GetCurrencySymbol(),
+		"symbol":   h.service.GetCurrencySymbol(),
 	})
 }
 
 // ToggleDarkMode toggles dark mode preference
 func (h *SettingsHandler) ToggleDarkMode(c *gin.Context) {
 	enabled := c.PostForm("enabled") == "true"
-	
+
 	err := h.service.SetDarkMode(enabled)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	
+
 	c.JSON(http.StatusOK, gin.H{
 		"dark_mode": enabled,
 	})

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -175,11 +175,17 @@
                         <div class="flex items-center justify-between">
                             <div id="smtp-message"></div>
                             <div class="flex space-x-2">
-                                <button type="button" 
-                                        hx-post="/api/settings/smtp/test" 
+                                <button type="button"
+                                        id="test-smtp-btn"
+                                        hx-post="/api/settings/smtp/test"
                                         hx-include="#smtp-form"
                                         hx-target="#smtp-message"
-                                        class="bg-gray-100 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-200">
+                                        hx-indicator="#smtp-spinner"
+                                        class="bg-gray-100 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-200 flex items-center">
+                                    <svg id="smtp-spinner" class="htmx-indicator animate-spin -ml-1 mr-2 h-4 w-4 text-gray-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                    </svg>
                                     Test Connection
                                 </button>
                                 <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary/90">


### PR DESCRIPTION
- Implement STARTTLS for standard SMTP ports (2525, 8025, 587, 25, 80)
- Add implicit TLS support for SSL ports (465, 8465, 443)
- Add loading spinner to test connection button for better user feedback
- Fix authentication failures with SMTP2Go and other providers requiring encryption
- Improve error messages to distinguish between SSL and STARTTLS connection failures
- Help with Claude to try this workflow out. 

Resolves #50