### PR TITLE
Add CHF and BRL currency support

### DIFF
--- a/internal/service/currency.go
+++ b/internal/service/currency.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SupportedCurrencies defines the list of currencies supported for exchange rates and settings
-var SupportedCurrencies = []string{"USD", "EUR", "GBP", "JPY", "RUB", "SEK", "PLN", "INR"}
+var SupportedCurrencies = []string{"USD", "EUR", "GBP", "JPY", "RUB", "SEK", "PLN", "INR", "CHF", "BRL"}
 
 // supportedCurrencySymbols returns the currencies as a comma-separated string for API calls
 func supportedCurrencySymbols() string {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -482,8 +482,32 @@
                                class="mr-2 text-primary focus:ring-primary">
                         <span class="text-sm font-medium text-gray-700 dark:text-gray-200">₹ INR (Indian Rupee)</span>
                     </label>
+
+                    <label class="flex items-center">
+                        <input type="radio"
+                               name="currency"
+                               value="CHF"
+                               {{if eq .Currency "CHF"}}checked{{end}}
+                               hx-post="/api/settings/currency"
+                               hx-trigger="change"
+                               hx-vals='{"currency": "CHF"}'
+                               class="mr-2 text-primary focus:ring-primary">
+                        <span class="text-sm font-medium text-gray-700 dark:text-gray-200">CHF (Swiss Franc)</span>
+                    </label>
+
+                    <label class="flex items-center">
+                        <input type="radio"
+                               name="currency"
+                               value="BRL"
+                               {{if eq .Currency "BRL"}}checked{{end}}
+                               hx-post="/api/settings/currency"
+                               hx-trigger="change"
+                               hx-vals='{"currency": "BRL"}'
+                               class="mr-2 text-primary focus:ring-primary">
+                        <span class="text-sm font-medium text-gray-700 dark:text-gray-200">R$ BRL (Brazilian Real)</span>
+                    </label>
                 </div>
-                
+
                 <div id="currency-message" class="mt-2"></div>
             </div>
 

--- a/templates/subscription-form.html
+++ b/templates/subscription-form.html
@@ -61,6 +61,8 @@
                     <option value="SEK" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "SEK"}}selected{{end}}{{end}}>kr SEK</option>
                     <option value="PLN" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "PLN"}}selected{{end}}{{end}}>zł PLN</option>
                     <option value="INR" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "INR"}}selected{{end}}{{end}}>₹ INR</option>
+                    <option value="CHF" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "CHF"}}selected{{end}}{{end}}>CHF</option>
+                    <option value="BRL" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "BRL"}}selected{{end}}{{end}}>R$ BRL</option>
                 </select>
             </div>
 


### PR DESCRIPTION
## Summary
- Adds CHF (Swiss Franc) currency support as requested in #63
- Adds BRL (Brazilian Real) currency support as requested in #66
- Updates supported currencies list, settings page, and subscription form

## Changes
- `internal/service/currency.go`: Added CHF and BRL to `SupportedCurrencies` slice
- `templates/settings.html`: Added radio buttons for CHF and BRL in currency settings
- `templates/subscription-form.html`: Added CHF and BRL options to currency dropdown

## Test plan
- [ ] Verify CHF and BRL appear in settings page currency options
- [ ] Verify CHF and BRL appear in subscription form currency dropdown
- [ ] Verify currency conversion works with Fixer API for CHF and BRL

Closes #63
Closes #66