### PR TITLE
v0.4.9 - New Currencies & UX Improvements

### DIFF
--- a/internal/service/currency.go
+++ b/internal/service/currency.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SupportedCurrencies defines the list of currencies supported for exchange rates and settings
-var SupportedCurrencies = []string{"USD", "EUR", "GBP", "JPY", "RUB", "SEK", "PLN", "INR"}
+var SupportedCurrencies = []string{"USD", "EUR", "GBP", "JPY", "RUB", "SEK", "PLN", "INR", "CHF", "BRL"}
 
 // supportedCurrencySymbols returns the currencies as a comma-separated string for API calls
 func supportedCurrencySymbols() string {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -492,7 +492,7 @@
                                hx-trigger="change"
                                hx-vals='{"currency": "CHF"}'
                                class="mr-2 text-primary focus:ring-primary">
-                        <span class="text-sm font-medium text-gray-700 dark:text-gray-200">CHF (Swiss Franc)</span>
+                        <span class="text-sm font-medium text-gray-700 dark:text-gray-200">Fr. CHF (Swiss Franc)</span>
                     </label>
 
                     <label class="flex items-center">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -482,8 +482,32 @@
                                class="mr-2 text-primary focus:ring-primary">
                         <span class="text-sm font-medium text-gray-700 dark:text-gray-200">₹ INR (Indian Rupee)</span>
                     </label>
+
+                    <label class="flex items-center">
+                        <input type="radio"
+                               name="currency"
+                               value="CHF"
+                               {{if eq .Currency "CHF"}}checked{{end}}
+                               hx-post="/api/settings/currency"
+                               hx-trigger="change"
+                               hx-vals='{"currency": "CHF"}'
+                               class="mr-2 text-primary focus:ring-primary">
+                        <span class="text-sm font-medium text-gray-700 dark:text-gray-200">CHF (Swiss Franc)</span>
+                    </label>
+
+                    <label class="flex items-center">
+                        <input type="radio"
+                               name="currency"
+                               value="BRL"
+                               {{if eq .Currency "BRL"}}checked{{end}}
+                               hx-post="/api/settings/currency"
+                               hx-trigger="change"
+                               hx-vals='{"currency": "BRL"}'
+                               class="mr-2 text-primary focus:ring-primary">
+                        <span class="text-sm font-medium text-gray-700 dark:text-gray-200">R$ BRL (Brazilian Real)</span>
+                    </label>
                 </div>
-                
+
                 <div id="currency-message" class="mt-2"></div>
             </div>
 

--- a/templates/subscription-form.html
+++ b/templates/subscription-form.html
@@ -28,13 +28,40 @@
             <!-- Category -->
             <div>
                 <label for="category_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Category *</label>
-                <select id="category_id" name="category_id" required
-                        class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition-colors duration-150">
-                    <option value="">Select category</option>
-                    {{range .Categories}}
-                        <option value="{{.ID}}" {{if $.Subscription}}{{if eq $.Subscription.CategoryID .ID}}selected{{end}}{{end}}>{{.Name}}</option>
-                    {{end}}
-                </select>
+                <div class="flex gap-2">
+                    <div class="flex-1" id="category-select-container">
+                        <select id="category_id" name="category_id" required
+                                class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition-colors duration-150">
+                            <option value="">Select category</option>
+                            {{range .Categories}}
+                                <option value="{{.ID}}" {{if $.Subscription}}{{if eq $.Subscription.CategoryID .ID}}selected{{end}}{{end}}>{{.Name}}</option>
+                            {{end}}
+                        </select>
+                    </div>
+                    <button type="button" id="add-category-btn" onclick="showNewCategoryInput()"
+                            class="px-3 py-2 text-sm font-medium text-primary bg-primary/10 border border-primary/30 rounded-lg hover:bg-primary/20 transition-colors duration-150"
+                            title="Add new category">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+                        </svg>
+                    </button>
+                </div>
+                <!-- Inline new category input (hidden by default) -->
+                <div id="new-category-container" class="hidden mt-2">
+                    <div class="flex gap-2">
+                        <input type="text" id="new-category-name" placeholder="New category name"
+                               class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition-colors duration-150">
+                        <button type="button" onclick="createNewCategory()"
+                                class="px-3 py-2 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors duration-150">
+                            Add
+                        </button>
+                        <button type="button" onclick="hideNewCategoryInput()"
+                                class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors duration-150">
+                            Cancel
+                        </button>
+                    </div>
+                    <div id="new-category-error" class="text-sm text-danger mt-1 hidden"></div>
+                </div>
             </div>
 
             <!-- Cost -->
@@ -61,7 +88,7 @@
                     <option value="SEK" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "SEK"}}selected{{end}}{{end}}>kr SEK</option>
                     <option value="PLN" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "PLN"}}selected{{end}}{{end}}>zł PLN</option>
                     <option value="INR" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "INR"}}selected{{end}}{{end}}>₹ INR</option>
-                    <option value="CHF" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "CHF"}}selected{{end}}{{end}}>CHF</option>
+                    <option value="CHF" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "CHF"}}selected{{end}}{{end}}>Fr. CHF</option>
                     <option value="BRL" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "BRL"}}selected{{end}}{{end}}>R$ BRL</option>
                 </select>
             </div>
@@ -197,6 +224,88 @@
 </div>
 
 <script>
+// Inline category creation functions
+function showNewCategoryInput() {
+    document.getElementById('new-category-container').classList.remove('hidden');
+    document.getElementById('add-category-btn').classList.add('hidden');
+    document.getElementById('new-category-name').focus();
+}
+
+function hideNewCategoryInput() {
+    document.getElementById('new-category-container').classList.add('hidden');
+    document.getElementById('add-category-btn').classList.remove('hidden');
+    document.getElementById('new-category-name').value = '';
+    document.getElementById('new-category-error').classList.add('hidden');
+}
+
+let isCreatingCategory = false;
+
+async function createNewCategory() {
+    // Prevent double-submission
+    if (isCreatingCategory) return;
+
+    const nameInput = document.getElementById('new-category-name');
+    const errorDiv = document.getElementById('new-category-error');
+    const addBtn = document.querySelector('#new-category-container button');
+    const name = nameInput.value.trim();
+
+    if (!name) {
+        errorDiv.textContent = 'Please enter a category name';
+        errorDiv.classList.remove('hidden');
+        return;
+    }
+
+    isCreatingCategory = true;
+    if (addBtn) addBtn.disabled = true;
+
+    try {
+        const response = await fetch('/api/categories', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ name: name }),
+        });
+
+        if (!response.ok) {
+            const data = await response.json();
+            throw new Error(data.error || 'Failed to create category');
+        }
+
+        const newCategory = await response.json();
+
+        // Validate response before adding
+        if (!newCategory.id || !newCategory.name) {
+            throw new Error('Invalid response from server');
+        }
+
+        // Add new option to dropdown and select it
+        const select = document.getElementById('category_id');
+        const option = document.createElement('option');
+        option.value = newCategory.id;
+        option.textContent = newCategory.name;
+        option.selected = true;
+        select.appendChild(option);
+
+        // Hide the input and reset
+        hideNewCategoryInput();
+    } catch (error) {
+        errorDiv.textContent = error.message;
+        errorDiv.classList.remove('hidden');
+    } finally {
+        isCreatingCategory = false;
+        if (addBtn) addBtn.disabled = false;
+    }
+}
+
+// Allow Enter key to submit new category
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' && document.activeElement.id === 'new-category-name') {
+        e.preventDefault();
+        createNewCategory();
+    }
+});
+
 function calculateRenewalDate() {
     const scheduleSelect = document.getElementById('schedule');
     const statusSelect = document.getElementById('status');
@@ -257,15 +366,11 @@ function calculateRenewalDate() {
 // Add event listeners when modal content loads
 function initRenewalCalculator() {
     const scheduleSelect = document.getElementById('schedule');
-    const statusSelect = document.getElementById('status');
 
     if (scheduleSelect) {
         scheduleSelect.addEventListener('change', calculateRenewalDate);
     }
-
-    if (statusSelect) {
-        statusSelect.addEventListener('change', calculateRenewalDate);
-    }
+    // Note: Status changes should NOT trigger renewal date recalculation (fixes #68)
 }
 
 // Initialize immediately since this script loads with the form

--- a/templates/subscription-form.html
+++ b/templates/subscription-form.html
@@ -61,6 +61,8 @@
                     <option value="SEK" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "SEK"}}selected{{end}}{{end}}>kr SEK</option>
                     <option value="PLN" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "PLN"}}selected{{end}}{{end}}>zł PLN</option>
                     <option value="INR" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "INR"}}selected{{end}}{{end}}>₹ INR</option>
+                    <option value="CHF" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "CHF"}}selected{{end}}{{end}}>CHF</option>
+                    <option value="BRL" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "BRL"}}selected{{end}}{{end}}>R$ BRL</option>
                 </select>
             </div>
 


### PR DESCRIPTION
## Summary
- Adds CHF (Swiss Franc) and BRL (Brazilian Real) currency support
- Adds inline category creation from subscription form
- Fixes bug where status changes reset renewal date
- Adds Fr. symbol to CHF currency display

## Changes
- **New currencies**: CHF and BRL added to supported currencies list, settings page, and subscription form
- **Inline category creation**: Users can now create categories directly from the subscription form via a "+" button
- **Bug fix**: Status changes (Active/Cancelled/Paused/Trial) no longer recalculate the renewal date

## Test plan
- [x] Verify CHF and BRL appear in settings page currency options
- [x] Verify CHF and BRL appear in subscription form currency dropdown  
- [x] Verify inline category creation works from subscription form
- [x] Verify changing subscription status does not reset renewal date
- [x] Verify changing billing schedule still recalculates renewal date

Closes #63, #66, #67, #68