### PR TITLE
v0.5.2 - Currency Improvements

### DIFF
--- a/internal/service/currency.go
+++ b/internal/service/currency.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SupportedCurrencies defines the list of currencies supported for exchange rates and settings
-var SupportedCurrencies = []string{"USD", "EUR", "GBP", "JPY", "RUB", "SEK", "PLN", "INR", "CHF", "BRL"}
+var SupportedCurrencies = []string{"USD", "EUR", "GBP", "JPY", "RUB", "SEK", "PLN", "INR", "CHF", "BRL", "COP"}
 
 // supportedCurrencySymbols returns the currencies as a comma-separated string for API calls
 func supportedCurrencySymbols() string {

--- a/internal/service/settings.go
+++ b/internal/service/settings.go
@@ -223,6 +223,10 @@ func (s *SettingsService) GetCurrencySymbol() string {
 		return "kr"
 	case "INR":
 		return "₹"
+	case "CHF":
+		return "Fr."
+	case "BRL":
+		return "R$"
 	default:
 		return "$"
 	}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -284,7 +284,14 @@
             <div class="text-right">
                 {{if .ShowConversion}}
                 <p class="text-sm font-medium text-gray-900 dark:text-white">{{.DisplayCurrencySymbol}}{{printf "%.2f" .ConvertedCost}}</p>
-                <p class="text-xs text-gray-500 dark:text-gray-400">{{.OriginalCurrency}} {{printf "%.2f" .Cost}}</p>
+                <a href="https://fixer.io" target="_blank" rel="noopener"
+                   class="text-xs text-gray-500 dark:text-gray-400 hover:text-primary inline-flex items-center gap-1"
+                   title="Original amount before conversion (rates from Fixer.io)">
+                    {{.OriginalCurrency}} {{printf "%.2f" .Cost}}
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                    </svg>
+                </a>
                 {{else}}
                 <p class="text-sm font-medium text-gray-900 dark:text-white">{{$.CurrencySymbol}}{{printf "%.2f" .Cost}}</p>
                 {{end}}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -664,6 +664,18 @@
                                class="mr-2 text-primary focus:ring-primary">
                         <span class="text-sm font-medium text-gray-700 dark:text-gray-200">R$ BRL (Brazilian Real)</span>
                     </label>
+
+                    <label class="flex items-center">
+                        <input type="radio"
+                               name="currency"
+                               value="COP"
+                               {{if eq .Currency "COP"}}checked{{end}}
+                               hx-post="/api/settings/currency"
+                               hx-trigger="change"
+                               hx-vals='{"currency": "COP"}'
+                               class="mr-2 text-primary focus:ring-primary">
+                        <span class="text-sm font-medium text-gray-700 dark:text-gray-200">$ COP (Colombian Peso)</span>
+                    </label>
                 </div>
 
                 <div id="currency-message" class="mt-2"></div>

--- a/templates/subscription-form.html
+++ b/templates/subscription-form.html
@@ -90,6 +90,7 @@
                     <option value="INR" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "INR"}}selected{{end}}{{end}}>₹ INR</option>
                     <option value="CHF" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "CHF"}}selected{{end}}{{end}}>Fr. CHF</option>
                     <option value="BRL" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "BRL"}}selected{{end}}{{end}}>R$ BRL</option>
+                    <option value="COP" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "COP"}}selected{{end}}{{end}}>$ COP</option>
                 </select>
             </div>
 

--- a/templates/subscription-list.html
+++ b/templates/subscription-list.html
@@ -141,7 +141,14 @@
                 <td class="px-6 py-4 whitespace-nowrap">
                     {{if .ShowConversion}}
                     <div class="text-sm font-medium text-gray-900 dark:text-white">{{.DisplayCurrencySymbol}}{{printf "%.2f" .ConvertedCost}}</div>
-                    <div class="text-xs text-gray-500 dark:text-gray-400">{{.OriginalCurrency}} {{printf "%.2f" .Cost}}</div>
+                    <a href="https://fixer.io" target="_blank" rel="noopener"
+                       class="text-xs text-gray-500 dark:text-gray-400 hover:text-primary flex items-center gap-1"
+                       title="Original amount before conversion (rates from Fixer.io)">
+                        {{.OriginalCurrency}} {{printf "%.2f" .Cost}}
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                    </a>
                     {{else}}
                     <div class="text-sm font-medium text-gray-900 dark:text-white">{{$.CurrencySymbol}}{{printf "%.2f" .Cost}}</div>
                     {{end}}

--- a/templates/subscription-list.html
+++ b/templates/subscription-list.html
@@ -139,7 +139,12 @@
                     <div class="text-sm text-gray-900 dark:text-white">{{.Category.Name}}</div>
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap">
+                    {{if .ShowConversion}}
+                    <div class="text-sm font-medium text-gray-900 dark:text-white">{{.DisplayCurrencySymbol}}{{printf "%.2f" .ConvertedCost}}</div>
+                    <div class="text-xs text-gray-500 dark:text-gray-400">{{.OriginalCurrency}} {{printf "%.2f" .Cost}}</div>
+                    {{else}}
                     <div class="text-sm font-medium text-gray-900 dark:text-white">{{$.CurrencySymbol}}{{printf "%.2f" .Cost}}</div>
+                    {{end}}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap">
                     <div class="text-sm text-gray-900 dark:text-white">{{.Schedule}}</div>

--- a/templates/subscriptions.html
+++ b/templates/subscriptions.html
@@ -324,7 +324,19 @@
                         <div class="text-sm text-gray-900 dark:text-white">{{.Category.Name}}</div>
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap">
+                        {{if .ShowConversion}}
+                        <div class="text-sm font-medium text-gray-900 dark:text-white">{{.DisplayCurrencySymbol}}{{printf "%.2f" .ConvertedCost}}</div>
+                        <a href="https://fixer.io" target="_blank" rel="noopener"
+                           class="text-xs text-gray-500 dark:text-gray-400 hover:text-primary flex items-center gap-1"
+                           title="Original amount before conversion (rates from Fixer.io)">
+                            {{.OriginalCurrency}} {{printf "%.2f" .Cost}}
+                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                            </svg>
+                        </a>
+                        {{else}}
                         <div class="text-sm font-medium text-gray-900 dark:text-white">{{$.CurrencySymbol}}{{printf "%.2f" .Cost}}</div>
+                        {{end}}
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap">
                         <div class="text-sm text-gray-900 dark:text-white">{{.Schedule}}</div>


### PR DESCRIPTION
## Summary
- Add Colombian Peso (COP) currency support
- Fix currency conversion display in subscription list
- Fix missing BRL/CHF currency symbols
- Add info tooltip for currency conversions linking to Fixer.io

## Changes
- `internal/service/currency.go` - Add COP to supported currencies
- `internal/service/settings.go` - Add BRL (R$) and CHF (Fr.) symbol mappings
- `templates/settings.html` - Add COP radio button
- `templates/subscription-form.html` - Add COP dropdown option
- `templates/subscriptions.html` - Fix conversion display + add info tooltip
- `templates/subscription-list.html` - Fix conversion display + add info tooltip
- `templates/dashboard.html` - Add info tooltip for conversions

## Test plan
- [x] Verify COP appears in currency selectors
- [x] Verify BRL shows R$ symbol when selected
- [x] Verify currency conversion displays correctly in subscription list
- [x] Verify info icon tooltip appears on hover
- [x] Verify info icon links to fixer.io

Closes #78, Closes #79