### PR TITLE
feat: Add Pushover notifications and BDT currency support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ subtrackr-xyz/
 
 #### 2. Handlers (`internal/handlers/`)
 - **subscription.go**: CRUD operations for subscriptions
-- **settings.go**: SMTP config, notifications, API keys, currency, dark mode
+- **settings.go**: SMTP config, Pushover config, notifications, API keys, currency, dark mode
 - **category.go**: Category management
 
 #### 3. Services (`internal/service/`)
@@ -53,6 +53,8 @@ subtrackr-xyz/
 - **settings.go**: Settings management
 - **category.go**: Category operations
 - **currency.go**: Currency conversion (Fixer.io integration)
+- **email.go**: Email notification service (SMTP)
+- **pushover.go**: Pushover notification service
 
 #### 4. Models (`internal/models/`)
 - GORM models:
@@ -60,6 +62,7 @@ subtrackr-xyz/
   - `Category`: Subscription categories
   - `Settings`: Application settings (key-value store)
   - `SMTPConfig`: Email configuration
+  - `PushoverConfig`: Pushover notification configuration
   - `APIKey`: API authentication keys
   - `ExchangeRate`: Currency exchange rates
 
@@ -122,12 +125,20 @@ subtrackr-xyz/
    - Renewal reminders
    - High cost alerts
 
-3. **Currency Support**
-   - USD, EUR, GBP, JPY, RUB, SEK, PLN, INR
+3. **Pushover Notifications**
+   - Pushover API integration for mobile push notifications
+   - User Key and Application Token configuration
+   - Renewal reminders (same settings as email)
+   - High cost alerts (same threshold as email)
+   - Works alongside email notifications
+
+4. **Currency Support**
+   - USD, EUR, GBP, JPY, RUB, SEK, PLN, INR, CHF, BRL, COP, BDT
    - Optional Fixer.io integration for real-time rates
    - Automatic conversion display
+   - BDT (Bangladeshi Taka) with ৳ symbol
 
-4. **API Access**
+5. **API Access**
    - API key authentication
    - RESTful endpoints
    - JSON responses
@@ -218,9 +229,19 @@ This project uses versioned branches for releases. See `CLAUDE.md` for the compl
 4. Update date calculation logic if needed
 
 #### Adding a New Currency
-1. Update currency service with new symbol
-2. Add to currency selection in settings template
-3. Update exchange rate handling if using Fixer.io
+1. Add currency code to `SupportedCurrencies` in `internal/service/currency.go`
+2. Add currency symbol mapping in `GetCurrencySymbol()` in `internal/service/settings.go`
+3. Add currency option to currency selection in `templates/settings.html`
+4. Update exchange rate handling if using Fixer.io
+
+#### Adding a New Notification Method
+1. Create notification config model in `internal/models/settings.go`
+2. Create notification service in `internal/service/` (e.g., `pushover.go`)
+3. Add config save/get methods to `SettingsService`
+4. Add handlers in `internal/handlers/settings.go`
+5. Add UI in `templates/settings.html`
+6. Update subscription handler to send notifications
+7. Update renewal reminder scheduler in `cmd/server/main.go`
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ Themes persist across all pages and are saved per user. Change themes anytime fr
 - 📅 **Calendar View**: Visual calendar showing all subscription renewal dates with iCal export
 - 📈 **Analytics**: Visualize spending by category and track savings
 - 🔔 **Email Notifications**: Get reminders before subscriptions renew
+- 📱 **Pushover Notifications**: Receive push notifications on your mobile device
 - 📤 **Data Export**: Export your data as CSV, JSON, or iCal format
 - 🎨 **Beautiful Themes**: 5 stunning themes including a festive Christmas theme with snowfall animation
-- 🌍 **Multi-Currency Support**: Support for USD, EUR, GBP, JPY, RUB, SEK, PLN, and INR (with optional real-time conversion)
+- 🌍 **Multi-Currency Support**: Support for USD, EUR, GBP, JPY, RUB, SEK, PLN, INR, CHF, BRL, COP, and BDT (with optional real-time conversion)
 - 🐳 **Docker Ready**: Easy deployment with Docker
 - 🔒 **Self-Hosted**: Your data stays on your server
 - 📱 **Mobile Responsive**: Optimized mobile experience with hamburger menu navigation
@@ -251,7 +252,7 @@ SubTrackr supports automatic currency conversion using Fixer.io exchange rates:
 
 **Note:** The free Fixer.io plan only allows EUR as the base currency. SubTrackr automatically handles cross-rate calculations (e.g., USD→INR goes through EUR) so all currency conversions work correctly regardless of this limitation.
 
-**Supported currencies:** USD, EUR, GBP, JPY, RUB, SEK, PLN, INR
+**Supported currencies:** USD, EUR, GBP, JPY, RUB, SEK, PLN, INR, CHF, BRL, COP, BDT
 
 ### Email Notifications (SMTP)
 
@@ -264,6 +265,27 @@ Configure SMTP settings in the web interface:
    - **Custom**: Your SMTP server details
 3. Test connection
 4. Enable renewal reminders
+
+### Pushover Notifications
+
+Receive push notifications on your mobile device via Pushover:
+
+1. **Get your Pushover credentials**:
+   - Sign up at [pushover.net](https://pushover.net/) (free account)
+   - Get your User Key from the dashboard
+   - Create an application at [pushover.net/apps/build](https://pushover.net/apps/build) to get an Application Token
+
+2. **Configure in SubTrackr**:
+   - Navigate to Settings → Pushover Notifications
+   - Enter your User Key and Application Token
+   - Click "Test Connection" to verify configuration
+   - Save settings
+
+3. **Notification Types**:
+   - **Renewal Reminders**: Get notified before subscriptions renew (uses the same reminder days setting as email)
+   - **High Cost Alerts**: Receive alerts when adding expensive subscriptions (uses the same threshold as email alerts)
+
+**Note**: Pushover notifications work alongside email notifications. Both will be sent when enabled, giving you multiple ways to stay informed about your subscriptions.
 
 ### Data Persistence
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -56,6 +56,7 @@ func main() {
 	subscriptionService := service.NewSubscriptionService(subscriptionRepo, categoryService)
 	settingsService := service.NewSettingsService(settingsRepo)
 	emailService := service.NewEmailService(settingsService)
+	pushoverService := service.NewPushoverService(settingsService)
 	logoService := service.NewLogoService()
 
 	// Handle CLI commands (run before starting HTTP server)
@@ -77,7 +78,7 @@ func main() {
 	sessionService := service.NewSessionService(sessionSecret)
 
 	// Initialize handlers
-	subscriptionHandler := handlers.NewSubscriptionHandler(subscriptionService, settingsService, currencyService, emailService, logoService)
+	subscriptionHandler := handlers.NewSubscriptionHandler(subscriptionService, settingsService, currencyService, emailService, pushoverService, logoService)
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
 	categoryHandler := handlers.NewCategoryHandler(categoryService)
 	authHandler := handlers.NewAuthHandler(settingsService, sessionService, emailService)
@@ -170,7 +171,7 @@ func main() {
 	// }
 
 	// Start renewal reminder scheduler
-	go startRenewalReminderScheduler(subscriptionService, emailService, settingsService)
+	go startRenewalReminderScheduler(subscriptionService, emailService, pushoverService, settingsService)
 
 	// Start server
 	port := os.Getenv("PORT")
@@ -334,6 +335,9 @@ func setupRoutes(router *gin.Engine, handler *handlers.SubscriptionHandler, sett
 		// Settings routes
 		api.POST("/settings/smtp", settingsHandler.SaveSMTPSettings)
 		api.POST("/settings/smtp/test", settingsHandler.TestSMTPConnection)
+		api.POST("/settings/pushover", settingsHandler.SavePushoverSettings)
+		api.POST("/settings/pushover/test", settingsHandler.TestPushoverConnection)
+		api.GET("/settings/pushover", settingsHandler.GetPushoverConfig)
 		api.POST("/settings/notifications/:setting", settingsHandler.UpdateNotificationSetting)
 		api.GET("/settings/notifications", settingsHandler.GetNotificationSettings)
 		api.GET("/settings/smtp", settingsHandler.GetSMTPConfig)
@@ -390,12 +394,12 @@ func setupRoutes(router *gin.Engine, handler *handlers.SubscriptionHandler, sett
 }
 
 // startRenewalReminderScheduler starts a background goroutine that checks for
-// upcoming renewals and sends reminder emails daily
-func startRenewalReminderScheduler(subscriptionService *service.SubscriptionService, emailService *service.EmailService, settingsService *service.SettingsService) {
+// upcoming renewals and sends reminder emails and Pushover notifications daily
+func startRenewalReminderScheduler(subscriptionService *service.SubscriptionService, emailService *service.EmailService, pushoverService *service.PushoverService, settingsService *service.SettingsService) {
 	// Run immediately on startup (after a short delay to let server initialize)
 	go func() {
 		time.Sleep(30 * time.Second) // Wait 30 seconds for server to fully start
-		checkAndSendRenewalReminders(subscriptionService, emailService, settingsService)
+		checkAndSendRenewalReminders(subscriptionService, emailService, pushoverService, settingsService)
 	}()
 
 	// Then run daily at midnight
@@ -412,14 +416,14 @@ func startRenewalReminderScheduler(subscriptionService *service.SubscriptionServ
 						log.Printf("Panic in renewal reminder check: %v", r)
 					}
 				}()
-				checkAndSendRenewalReminders(subscriptionService, emailService, settingsService)
+				checkAndSendRenewalReminders(subscriptionService, emailService, pushoverService, settingsService)
 			}()
 		}
 	}()
 }
 
-// checkAndSendRenewalReminders checks for subscriptions needing reminders and sends emails
-func checkAndSendRenewalReminders(subscriptionService *service.SubscriptionService, emailService *service.EmailService, settingsService *service.SettingsService) {
+// checkAndSendRenewalReminders checks for subscriptions needing reminders and sends emails and Pushover notifications
+func checkAndSendRenewalReminders(subscriptionService *service.SubscriptionService, emailService *service.EmailService, pushoverService *service.PushoverService, settingsService *service.SettingsService) {
 	// Check if renewal reminders are enabled
 	enabled, err := settingsService.GetBoolSetting("renewal_reminders", false)
 	if err != nil || !enabled {
@@ -446,13 +450,16 @@ func checkAndSendRenewalReminders(subscriptionService *service.SubscriptionServi
 
 	log.Printf("Checking %d subscription(s) for renewal reminders", len(subscriptions))
 
-	// Send reminder for each subscription
+	// Send reminder for each subscription (both email and Pushover)
 	sentCount := 0
 	failedCount := 0
 	for sub, daysUntil := range subscriptions {
-		err := emailService.SendRenewalReminder(sub, daysUntil)
-		if err != nil {
-			log.Printf("Error sending renewal reminder for subscription %s (ID: %d): %v", sub.Name, sub.ID, err)
+		emailErr := emailService.SendRenewalReminder(sub, daysUntil)
+		pushoverErr := pushoverService.SendRenewalReminder(sub, daysUntil)
+
+		// If both fail, count as failed; otherwise consider it sent
+		if emailErr != nil && pushoverErr != nil {
+			log.Printf("Error sending renewal reminder for subscription %s (ID: %d): email=%v, pushover=%v", sub.Name, sub.ID, emailErr, pushoverErr)
 			failedCount++
 		} else {
 			// Mark reminder as sent for this renewal date
@@ -469,7 +476,13 @@ func checkAndSendRenewalReminders(subscriptionService *service.SubscriptionServi
 				log.Printf("Warning: Failed to update last reminder sent for subscription %s (ID: %d): %v", sub.Name, sub.ID, updateErr)
 			}
 
-			log.Printf("Sent renewal reminder for subscription %s (renews in %d days)", sub.Name, daysUntil)
+			if emailErr != nil {
+				log.Printf("Sent Pushover renewal reminder for subscription %s (renews in %d days) - email failed: %v", sub.Name, daysUntil, emailErr)
+			} else if pushoverErr != nil {
+				log.Printf("Sent email renewal reminder for subscription %s (renews in %d days) - Pushover failed: %v", sub.Name, daysUntil, pushoverErr)
+			} else {
+				log.Printf("Sent renewal reminders (email and Pushover) for subscription %s (renews in %d days)", sub.Name, daysUntil)
+			}
 			sentCount++
 		}
 	}

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -32,15 +32,17 @@ type SubscriptionHandler struct {
 	settingsService *service.SettingsService
 	currencyService *service.CurrencyService
 	emailService    *service.EmailService
+	pushoverService *service.PushoverService
 	logoService     *service.LogoService
 }
 
-func NewSubscriptionHandler(service *service.SubscriptionService, settingsService *service.SettingsService, currencyService *service.CurrencyService, emailService *service.EmailService, logoService *service.LogoService) *SubscriptionHandler {
+func NewSubscriptionHandler(service *service.SubscriptionService, settingsService *service.SettingsService, currencyService *service.CurrencyService, emailService *service.EmailService, pushoverService *service.PushoverService, logoService *service.LogoService) *SubscriptionHandler {
 	return &SubscriptionHandler{
 		service:         service,
 		settingsService: settingsService,
 		currencyService: currencyService,
 		emailService:    emailService,
+		pushoverService: pushoverService,
 		logoService:     logoService,
 	}
 }
@@ -394,6 +396,15 @@ func (h *SubscriptionHandler) Settings(c *gin.Context) {
 		smtpConfigured = true
 	}
 
+	// Load Pushover config if available
+	var pushoverConfig *models.PushoverConfig
+	pushoverConfigured := false
+	pushoverCfg, err := h.settingsService.GetPushoverConfig()
+	if err == nil && pushoverCfg != nil {
+		pushoverConfig = pushoverCfg
+		pushoverConfigured = true
+	}
+
 	// Get auth settings
 	authEnabled := h.settingsService.IsAuthEnabled()
 	authUsername, _ := h.settingsService.GetAuthUsername()
@@ -405,6 +416,8 @@ func (h *SubscriptionHandler) Settings(c *gin.Context) {
 		"CurrencySymbol":     h.settingsService.GetCurrencySymbol(),
 		"RenewalReminders":   h.settingsService.GetBoolSettingWithDefault("renewal_reminders", false),
 		"HighCostAlerts":     h.settingsService.GetBoolSettingWithDefault("high_cost_alerts", true),
+		"PushoverConfig":     pushoverConfig,
+		"PushoverConfigured": pushoverConfigured,
 		"HighCostThreshold":  h.settingsService.GetFloatSettingWithDefault("high_cost_threshold", 50.0),
 		"ReminderDays":       h.settingsService.GetIntSettingWithDefault("reminder_days", 7),
 		"DarkMode":           h.settingsService.IsDarkModeEnabled(),
@@ -512,14 +525,20 @@ func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 		return
 	}
 
-	// Send high-cost alert email if applicable
+	// Send high-cost alert email and Pushover notification if applicable
 	if h.isHighCostWithCurrency(created) {
 		// Reload subscription with category for email template
 		subscriptionWithCategory, err := h.service.GetByID(created.ID)
 		if err == nil && subscriptionWithCategory != nil {
+			// Send email notification
 			if err := h.emailService.SendHighCostAlert(subscriptionWithCategory); err != nil {
 				// Log error but don't fail the request
 				log.Printf("Failed to send high-cost alert email: %v", err)
+			}
+			// Send Pushover notification
+			if err := h.pushoverService.SendHighCostAlert(subscriptionWithCategory); err != nil {
+				// Log error but don't fail the request
+				log.Printf("Failed to send high-cost alert Pushover notification: %v", err)
 			}
 		}
 	}
@@ -618,14 +637,20 @@ func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 		return
 	}
 
-	// Send high-cost alert email if subscription became high-cost (wasn't before, but is now)
+	// Send high-cost alert email and Pushover notification if subscription became high-cost (wasn't before, but is now)
 	if updated != nil && !wasHighCost && h.isHighCostWithCurrency(updated) {
 		// Reload subscription with category for email template
 		subscriptionWithCategory, err := h.service.GetByID(updated.ID)
 		if err == nil && subscriptionWithCategory != nil {
+			// Send email notification
 			if err := h.emailService.SendHighCostAlert(subscriptionWithCategory); err != nil {
 				// Log error but don't fail the request
 				log.Printf("Failed to send high-cost alert email: %v", err)
+			}
+			// Send Pushover notification
+			if err := h.pushoverService.SendHighCostAlert(subscriptionWithCategory); err != nil {
+				// Log error but don't fail the request
+				log.Printf("Failed to send high-cost alert Pushover notification: %v", err)
 			}
 		}
 	}

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -24,6 +24,12 @@ type SMTPConfig struct {
 	To       string `json:"smtp_to"` // Recipient email address for notifications
 }
 
+// PushoverConfig represents Pushover notification configuration
+type PushoverConfig struct {
+	UserKey  string `json:"pushover_user_key"`  // Pushover user key
+	AppToken string `json:"pushover_app_token"` // Pushover application token
+}
+
 // NotificationSettings represents notification preferences
 type NotificationSettings struct {
 	RenewalReminders  bool    `json:"renewal_reminders"`
@@ -34,12 +40,12 @@ type NotificationSettings struct {
 
 // APIKey represents an API key for external access
 type APIKey struct {
-	ID          uint      `json:"id" gorm:"primaryKey"`
-	Name        string    `json:"name" gorm:"not null"`
-	Key         string    `json:"key" gorm:"uniqueIndex;not null"`
-	LastUsed    *time.Time `json:"last_used"`
-	UsageCount  int       `json:"usage_count" gorm:"default:0"`
-	CreatedAt   time.Time `json:"created_at" gorm:"autoCreateTime"`
-	UpdatedAt   time.Time `json:"updated_at" gorm:"autoUpdateTime"`
-	IsNew       bool      `json:"is_new" gorm:"-"` // Not stored in DB, just for display
+	ID         uint       `json:"id" gorm:"primaryKey"`
+	Name       string     `json:"name" gorm:"not null"`
+	Key        string     `json:"key" gorm:"uniqueIndex;not null"`
+	LastUsed   *time.Time `json:"last_used"`
+	UsageCount int        `json:"usage_count" gorm:"default:0"`
+	CreatedAt  time.Time  `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt  time.Time  `json:"updated_at" gorm:"autoUpdateTime"`
+	IsNew      bool       `json:"is_new" gorm:"-"` // Not stored in DB, just for display
 }

--- a/internal/service/currency.go
+++ b/internal/service/currency.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SupportedCurrencies defines the list of currencies supported for exchange rates and settings
-var SupportedCurrencies = []string{"USD", "EUR", "GBP", "JPY", "RUB", "SEK", "PLN", "INR", "CHF", "BRL", "COP"}
+var SupportedCurrencies = []string{"USD", "EUR", "GBP", "JPY", "RUB", "SEK", "PLN", "INR", "CHF", "BRL", "COP", "BDT"}
 
 // supportedCurrencySymbols returns the currencies as a comma-separated string for API calls
 func supportedCurrencySymbols() string {

--- a/internal/service/pushover.go
+++ b/internal/service/pushover.go
@@ -1,0 +1,156 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"subtrackr/internal/models"
+	"time"
+)
+
+// PushoverService handles sending notifications via Pushover
+type PushoverService struct {
+	settingsService *SettingsService
+}
+
+// NewPushoverService creates a new Pushover service
+func NewPushoverService(settingsService *SettingsService) *PushoverService {
+	return &PushoverService{
+		settingsService: settingsService,
+	}
+}
+
+// PushoverResponse represents the response from Pushover API
+type PushoverResponse struct {
+	Status  int      `json:"status"`
+	Request string   `json:"request"`
+	Errors  []string `json:"errors,omitempty"`
+}
+
+// SendNotification sends a notification via Pushover
+func (p *PushoverService) SendNotification(title, message string, priority int) error {
+	config, err := p.settingsService.GetPushoverConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get Pushover config: %w", err)
+	}
+
+	if config.UserKey == "" || config.AppToken == "" {
+		return fmt.Errorf("Pushover not configured: user key and app token required")
+	}
+
+	// Pushover API endpoint
+	apiURL := "https://api.pushover.net/1/messages.json"
+
+	// Prepare form data
+	formData := url.Values{}
+	formData.Set("token", config.AppToken)
+	formData.Set("user", config.UserKey)
+	formData.Set("title", title)
+	formData.Set("message", message)
+	formData.Set("priority", strconv.Itoa(priority))
+
+	// Create HTTP request
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBufferString(formData.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// Send request
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send Pushover notification: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Parse response
+	var pushoverResp PushoverResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pushoverResp); err != nil {
+		return fmt.Errorf("failed to decode Pushover response: %w", err)
+	}
+
+	if pushoverResp.Status != 1 {
+		errorMsg := "Pushover API error"
+		if len(pushoverResp.Errors) > 0 {
+			errorMsg = pushoverResp.Errors[0]
+		}
+		return fmt.Errorf("%s", errorMsg)
+	}
+
+	return nil
+}
+
+// SendHighCostAlert sends a Pushover alert when a high-cost subscription is created
+func (p *PushoverService) SendHighCostAlert(subscription *models.Subscription) error {
+	// Check if high cost alerts are enabled
+	enabled, err := p.settingsService.GetBoolSetting("high_cost_alerts", true)
+	if err != nil || !enabled {
+		return nil // Silently skip if disabled
+	}
+
+	// Get currency symbol
+	currencySymbol := p.settingsService.GetCurrencySymbol()
+
+	// Build message
+	message := "⚠️ High Cost Alert\n\n"
+	message += fmt.Sprintf("Subscription: %s\n", subscription.Name)
+	message += fmt.Sprintf("Cost: %s%.2f %s\n", currencySymbol, subscription.Cost, subscription.Schedule)
+	message += fmt.Sprintf("Monthly Cost: %s%.2f\n", currencySymbol, subscription.MonthlyCost())
+	if subscription.Category.Name != "" {
+		message += fmt.Sprintf("Category: %s\n", subscription.Category.Name)
+	}
+	if subscription.RenewalDate != nil {
+		message += fmt.Sprintf("Next Renewal: %s\n", subscription.RenewalDate.Format("January 2, 2006"))
+	}
+	if subscription.URL != "" {
+		message += fmt.Sprintf("URL: %s", subscription.URL)
+	}
+
+	title := fmt.Sprintf("High Cost Alert: %s", subscription.Name)
+	// Priority 1 = high priority (with sound and vibration)
+	return p.SendNotification(title, message, 1)
+}
+
+// SendRenewalReminder sends a Pushover reminder for an upcoming subscription renewal
+func (p *PushoverService) SendRenewalReminder(subscription *models.Subscription, daysUntilRenewal int) error {
+	// Check if renewal reminders are enabled
+	enabled, err := p.settingsService.GetBoolSetting("renewal_reminders", false)
+	if err != nil || !enabled {
+		return nil // Silently skip if disabled
+	}
+
+	// Get currency symbol
+	currencySymbol := p.settingsService.GetCurrencySymbol()
+
+	// Build message
+	daysText := "days"
+	if daysUntilRenewal == 1 {
+		daysText = "day"
+	}
+	message := "🔔 Renewal Reminder\n\n"
+	message += fmt.Sprintf("Your subscription %s will renew in %d %s.\n\n", subscription.Name, daysUntilRenewal, daysText)
+	message += "Subscription Details:\n"
+	message += fmt.Sprintf("Cost: %s%.2f %s\n", currencySymbol, subscription.Cost, subscription.Schedule)
+	message += fmt.Sprintf("Monthly Cost: %s%.2f\n", currencySymbol, subscription.MonthlyCost())
+	if subscription.Category.Name != "" {
+		message += fmt.Sprintf("Category: %s\n", subscription.Category.Name)
+	}
+	if subscription.RenewalDate != nil {
+		message += fmt.Sprintf("Renewal Date: %s\n", subscription.RenewalDate.Format("January 2, 2006"))
+	}
+	if subscription.URL != "" {
+		message += fmt.Sprintf("URL: %s", subscription.URL)
+	}
+
+	title := fmt.Sprintf("Renewal Reminder: %s", subscription.Name)
+	// Priority 0 = normal priority
+	return p.SendNotification(title, message, 0)
+}
+

--- a/internal/service/pushover_test.go
+++ b/internal/service/pushover_test.go
@@ -1,0 +1,406 @@
+package service
+
+import (
+	"os"
+	"subtrackr/internal/models"
+	"subtrackr/internal/repository"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// Pushover Test Credentials Usage:
+//
+// For unit tests (default): Tests use mock credentials and will fail API calls (expected behavior)
+//
+// For integration tests: Set environment variables before running tests:
+//   export PUSHOVER_USER_KEY="your_user_key_here"
+//   export PUSHOVER_APP_TOKEN="your_app_token_here"
+//
+// Integration tests will automatically skip if credentials are not provided.
+// Example:
+//   PUSHOVER_USER_KEY="u1234567890abcdef" PUSHOVER_APP_TOKEN="a1b2c3d4e5f6g7h8" go test ./internal/service -run Integration
+
+func setupPushoverTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("Failed to open test database: %v", err)
+	}
+
+	// Migrate the schema
+	err = db.AutoMigrate(
+		&models.Settings{},
+		&models.Category{},
+	)
+	if err != nil {
+		t.Fatalf("Failed to migrate test database: %v", err)
+	}
+
+	return db
+}
+
+func TestPushoverService_SendNotification_NoConfig(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Try to send notification without config
+	err := pushoverService.SendNotification("Test", "Test message", 0)
+	assert.Error(t, err, "Should return error when Pushover is not configured")
+	// Error will be "failed to get Pushover config: record not found" when no config exists
+	assert.Contains(t, err.Error(), "Pushover config", "Error should mention Pushover config")
+}
+
+func TestPushoverService_SendNotification_EmptyUserKey(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Configure with empty user key (but valid app token)
+	config := &models.PushoverConfig{
+		UserKey:  "", // Empty user key
+		AppToken: "test-app-token",
+	}
+	settingsService.SavePushoverConfig(config)
+
+	err := pushoverService.SendNotification("Test", "Test message", 0)
+	assert.Error(t, err, "Should return error when User Key is empty")
+	assert.Contains(t, err.Error(), "not configured", "Error should mention not configured")
+}
+
+func TestPushoverService_SendNotification_EmptyAppToken(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Configure with empty app token
+	config := &models.PushoverConfig{
+		UserKey:  "test-user-key",
+		AppToken: "",
+	}
+	settingsService.SavePushoverConfig(config)
+
+	err := pushoverService.SendNotification("Test", "Test message", 0)
+	assert.Error(t, err, "Should return error when App Token is empty")
+	assert.Contains(t, err.Error(), "not configured", "Error should mention not configured")
+}
+
+func TestPushoverService_SendHighCostAlert_Disabled(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Ensure high cost alerts are disabled
+	settingsService.SetBoolSetting("high_cost_alerts", false)
+
+	subscription := &models.Subscription{
+		Name:     "Test Subscription",
+		Cost:     100.00,
+		Schedule: "Monthly",
+		Status:   "Active",
+		Category: models.Category{Name: "Test"},
+	}
+
+	// Should return nil without error when disabled
+	err := pushoverService.SendHighCostAlert(subscription)
+	assert.NoError(t, err, "Should return nil when high cost alerts are disabled")
+}
+
+func TestPushoverService_SendHighCostAlert_EnabledButNoConfig(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Enable high cost alerts but don't configure Pushover
+	settingsService.SetBoolSetting("high_cost_alerts", true)
+	settingsService.SetCurrency("USD")
+
+	subscription := &models.Subscription{
+		Name:     "Test Subscription",
+		Cost:     100.00,
+		Schedule: "Monthly",
+		Status:   "Active",
+		Category: models.Category{Name: "Test"},
+	}
+
+	// Should return error when Pushover is not configured
+	err := pushoverService.SendHighCostAlert(subscription)
+	assert.Error(t, err, "Should return error when Pushover is not configured")
+}
+
+func TestPushoverService_SendRenewalReminder_Disabled(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Ensure renewal reminders are disabled
+	settingsService.SetBoolSetting("renewal_reminders", false)
+
+	subscription := &models.Subscription{
+		Name:        "Test Subscription",
+		Cost:        10.00,
+		Schedule:    "Monthly",
+		Status:      "Active",
+		RenewalDate: timePtr(time.Now().AddDate(0, 0, 3)),
+		Category:    models.Category{Name: "Test"},
+	}
+
+	// Should return nil without error when disabled
+	err := pushoverService.SendRenewalReminder(subscription, 3)
+	assert.NoError(t, err, "Should return nil when renewal reminders are disabled")
+}
+
+func TestPushoverService_SendRenewalReminder_EnabledButNoConfig(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Enable renewal reminders but don't configure Pushover
+	settingsService.SetBoolSetting("renewal_reminders", true)
+	settingsService.SetCurrency("USD")
+
+	subscription := &models.Subscription{
+		Name:        "Test Subscription",
+		Cost:        10.00,
+		Schedule:    "Monthly",
+		Status:      "Active",
+		RenewalDate: timePtr(time.Now().AddDate(0, 0, 3)),
+		Category:    models.Category{Name: "Test"},
+	}
+
+	// Should return error when Pushover is not configured
+	err := pushoverService.SendRenewalReminder(subscription, 3)
+	assert.Error(t, err, "Should return error when Pushover is not configured")
+}
+
+func TestPushoverService_SendHighCostAlert_MessageFormat(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Configure Pushover with invalid credentials (we're testing message format, not actual sending)
+	config := &models.PushoverConfig{
+		UserKey:  "test-user-key",
+		AppToken: "test-app-token",
+	}
+	settingsService.SavePushoverConfig(config)
+	settingsService.SetBoolSetting("high_cost_alerts", true)
+	settingsService.SetCurrency("USD")
+
+	subscription := &models.Subscription{
+		Name:        "Netflix",
+		Cost:        15.99,
+		Schedule:    "Monthly",
+		Status:      "Active",
+		RenewalDate: timePtr(time.Now().AddDate(0, 0, 30)),
+		Category:    models.Category{Name: "Entertainment"},
+		URL:         "https://netflix.com",
+	}
+
+	// This will fail because we don't have real Pushover credentials, but it should attempt to send
+	err := pushoverService.SendHighCostAlert(subscription)
+	// We expect an error because we can't actually connect to Pushover API, but the function should attempt to send
+	assert.Error(t, err, "Should return error when Pushover API call fails (expected in test)")
+	// The error should be about API call, not about being disabled
+	assert.NotContains(t, err.Error(), "disabled", "Error should not be about being disabled")
+}
+
+func TestPushoverService_SendRenewalReminder_MessageFormat(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Configure Pushover with invalid credentials (we're testing message format, not actual sending)
+	config := &models.PushoverConfig{
+		UserKey:  "test-user-key",
+		AppToken: "test-app-token",
+	}
+	settingsService.SavePushoverConfig(config)
+	settingsService.SetBoolSetting("renewal_reminders", true)
+	settingsService.SetCurrency("USD")
+
+	subscription := &models.Subscription{
+		Name:        "Netflix",
+		Cost:        15.99,
+		Schedule:    "Monthly",
+		Status:      "Active",
+		RenewalDate: timePtr(time.Now().AddDate(0, 0, 3)),
+		Category:    models.Category{Name: "Entertainment"},
+		URL:         "https://netflix.com",
+	}
+
+	// This will fail because we don't have real Pushover credentials, but it should attempt to send
+	err := pushoverService.SendRenewalReminder(subscription, 3)
+	// We expect an error because we can't actually connect to Pushover API, but the function should attempt to send
+	assert.Error(t, err, "Should return error when Pushover API call fails (expected in test)")
+	// The error should be about API call, not about being disabled
+	assert.NotContains(t, err.Error(), "disabled", "Error should not be about being disabled")
+}
+
+func TestPushoverService_SendRenewalReminder_DaysText(t *testing.T) {
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Configure Pushover
+	config := &models.PushoverConfig{
+		UserKey:  "test-user-key",
+		AppToken: "test-app-token",
+	}
+	settingsService.SavePushoverConfig(config)
+	settingsService.SetBoolSetting("renewal_reminders", true)
+	settingsService.SetCurrency("USD")
+
+	subscription := &models.Subscription{
+		Name:        "Test Subscription",
+		Cost:        10.00,
+		Schedule:    "Monthly",
+		Status:      "Active",
+		RenewalDate: timePtr(time.Now().AddDate(0, 0, 1)),
+		Category:    models.Category{Name: "Test"},
+	}
+
+	tests := []struct {
+		name             string
+		daysUntil        int
+		expectedDaysText string
+	}{
+		{
+			name:             "Singular day",
+			daysUntil:        1,
+			expectedDaysText: "day",
+		},
+		{
+			name:             "Plural days",
+			daysUntil:        3,
+			expectedDaysText: "days",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This will fail because we don't have real Pushover credentials
+			err := pushoverService.SendRenewalReminder(subscription, tt.daysUntil)
+			assert.Error(t, err, "Should return error when Pushover API call fails (expected in test)")
+			// Verify the function attempted to send (not disabled)
+			assert.NotContains(t, err.Error(), "disabled", "Error should not be about being disabled")
+		})
+	}
+}
+
+// getPushoverTestCredentials retrieves Pushover credentials from environment variables for integration testing
+// Returns empty strings if not set (for unit tests)
+func getPushoverTestCredentials() (userKey, appToken string) {
+	userKey = os.Getenv("PUSHOVER_USER_KEY")
+	appToken = os.Getenv("PUSHOVER_APP_TOKEN")
+	return userKey, appToken
+}
+
+// TestPushoverService_SendNotification_Integration tests sending a real notification if credentials are provided
+// This is an optional integration test that only runs if PUSHOVER_USER_KEY and PUSHOVER_APP_TOKEN are set
+func TestPushoverService_SendNotification_Integration(t *testing.T) {
+	userKey, appToken := getPushoverTestCredentials()
+	if userKey == "" || appToken == "" {
+		t.Skip("Skipping integration test: PUSHOVER_USER_KEY and PUSHOVER_APP_TOKEN environment variables not set")
+	}
+
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Configure Pushover with real credentials from environment
+	config := &models.PushoverConfig{
+		UserKey:  userKey,
+		AppToken: appToken,
+	}
+	err := settingsService.SavePushoverConfig(config)
+	assert.NoError(t, err, "Should save Pushover config")
+
+	// Send a test notification
+	err = pushoverService.SendNotification("SubTrackr Test", "This is a test notification from SubTrackr integration tests", 0)
+	assert.NoError(t, err, "Should successfully send notification with valid credentials")
+}
+
+// TestPushoverService_SendHighCostAlert_Integration tests sending a real high cost alert if credentials are provided
+func TestPushoverService_SendHighCostAlert_Integration(t *testing.T) {
+	userKey, appToken := getPushoverTestCredentials()
+	if userKey == "" || appToken == "" {
+		t.Skip("Skipping integration test: PUSHOVER_USER_KEY and PUSHOVER_APP_TOKEN environment variables not set")
+	}
+
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Configure Pushover with real credentials
+	config := &models.PushoverConfig{
+		UserKey:  userKey,
+		AppToken: appToken,
+	}
+	settingsService.SavePushoverConfig(config)
+	settingsService.SetBoolSetting("high_cost_alerts", true)
+	settingsService.SetCurrency("USD")
+
+	subscription := &models.Subscription{
+		Name:        "Test High Cost Subscription",
+		Cost:        100.00,
+		Schedule:    "Monthly",
+		Status:      "Active",
+		RenewalDate: timePtr(time.Now().AddDate(0, 0, 30)),
+		Category:    models.Category{Name: "Test"},
+		URL:         "https://example.com",
+	}
+
+	err := pushoverService.SendHighCostAlert(subscription)
+	assert.NoError(t, err, "Should successfully send high cost alert with valid credentials")
+}
+
+// TestPushoverService_SendRenewalReminder_Integration tests sending a real renewal reminder if credentials are provided
+func TestPushoverService_SendRenewalReminder_Integration(t *testing.T) {
+	userKey, appToken := getPushoverTestCredentials()
+	if userKey == "" || appToken == "" {
+		t.Skip("Skipping integration test: PUSHOVER_USER_KEY and PUSHOVER_APP_TOKEN environment variables not set")
+	}
+
+	db := setupPushoverTestDB(t)
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := NewSettingsService(settingsRepo)
+	pushoverService := NewPushoverService(settingsService)
+
+	// Configure Pushover with real credentials
+	config := &models.PushoverConfig{
+		UserKey:  userKey,
+		AppToken: appToken,
+	}
+	settingsService.SavePushoverConfig(config)
+	settingsService.SetBoolSetting("renewal_reminders", true)
+	settingsService.SetCurrency("USD")
+
+	subscription := &models.Subscription{
+		Name:        "Test Subscription",
+		Cost:        15.99,
+		Schedule:    "Monthly",
+		Status:      "Active",
+		RenewalDate: timePtr(time.Now().AddDate(0, 0, 3)),
+		Category:    models.Category{Name: "Test"},
+		URL:         "https://example.com",
+	}
+
+	err := pushoverService.SendRenewalReminder(subscription, 3)
+	assert.NoError(t, err, "Should successfully send renewal reminder with valid credentials")
+}

--- a/internal/service/settings.go
+++ b/internal/service/settings.go
@@ -227,6 +227,8 @@ func (s *SettingsService) GetCurrencySymbol() string {
 		return "Fr."
 	case "BRL":
 		return "R$"
+	case "BDT":
+		return "৳"
 	default:
 		return "$"
 	}
@@ -394,4 +396,31 @@ func (s *SettingsService) ClearResetToken() error {
 	s.repo.Delete("auth_reset_token")
 	s.repo.Delete("auth_reset_token_expiry")
 	return nil
+}
+
+// SavePushoverConfig saves Pushover configuration
+func (s *SettingsService) SavePushoverConfig(config *models.PushoverConfig) error {
+	// Convert to JSON
+	data, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+	
+	return s.repo.Set("pushover_config", string(data))
+}
+
+// GetPushoverConfig retrieves Pushover configuration
+func (s *SettingsService) GetPushoverConfig() (*models.PushoverConfig, error) {
+	data, err := s.repo.Get("pushover_config")
+	if err != nil {
+		return nil, err
+	}
+	
+	var config models.PushoverConfig
+	err = json.Unmarshal([]byte(data), &config)
+	if err != nil {
+		return nil, err
+	}
+	
+	return &config, nil
 }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -457,6 +457,56 @@
                 </div>
             </div>
 
+            <!-- Pushover Notifications -->
+            <div class="border-t border-gray-200 dark:border-gray-700 pt-8">
+                <h3 class="text-base font-medium text-gray-900 dark:text-white mb-4">Pushover Notifications</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">Receive push notifications on your mobile device via Pushover</p>
+                
+                <!-- Pushover Settings -->
+                <div class="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-4 mb-4 transition-colors duration-200">
+                    <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-4">Pushover Configuration</h4>
+                    <form id="pushover-form" hx-post="/api/settings/pushover" hx-trigger="submit" hx-target="#pushover-message" hx-swap="innerHTML">
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                            <div>
+                                <label for="pushover_user_key" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">User Key</label>
+                                <input type="text" id="pushover_user_key" name="pushover_user_key" placeholder="Your Pushover User Key" value="{{if .PushoverConfig}}{{.PushoverConfig.UserKey}}{{end}}"
+                                       class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded-lg focus:ring-2 focus:ring-primary focus:border-primary text-sm transition-colors duration-150">
+                                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Get your User Key from <a href="https://pushover.net/" target="_blank" class="text-primary hover:underline">pushover.net</a></p>
+                            </div>
+                            <div>
+                                <label for="pushover_app_token" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Application Token</label>
+                                <input type="text" id="pushover_app_token" name="pushover_app_token" placeholder="Your Application Token" value="{{if .PushoverConfig}}{{.PushoverConfig.AppToken}}{{end}}"
+                                       class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded-lg focus:ring-2 focus:ring-primary focus:border-primary text-sm transition-colors duration-150">
+                                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Create an application at <a href="https://pushover.net/apps/build" target="_blank" class="text-primary hover:underline">pushover.net/apps</a></p>
+                            </div>
+                        </div>
+                        <div class="mb-4">
+                            <div id="pushover-message"></div>
+                        </div>
+                        <div class="flex items-center justify-end">
+                            <div class="flex space-x-2">
+                                <button type="button"
+                                        id="test-pushover-btn"
+                                        hx-post="/api/settings/pushover/test"
+                                        hx-include="#pushover-form"
+                                        hx-target="#pushover-message"
+                                        hx-indicator="#pushover-spinner"
+                                        class="bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-200 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-200 dark:hover:bg-gray-500 flex items-center transition-colors duration-150">
+                                    <svg id="pushover-spinner" class="htmx-indicator animate-spin -ml-1 mr-2 h-4 w-4 text-gray-700 dark:text-gray-200" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                    </svg>
+                                    Test Connection
+                                </button>
+                                <button type="submit" class="bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary/90">
+                                    Save Pushover Settings
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
             <!-- Security Settings -->
             <div class="border-t border-gray-200 dark:border-gray-700 pt-8">
                 <h3 class="text-base font-medium text-gray-900 dark:text-white mb-4">Security</h3>
@@ -679,6 +729,18 @@
                                hx-vals='{"currency": "COP"}'
                                class="mr-2 text-primary focus:ring-primary">
                         <span class="text-sm font-medium text-gray-700 dark:text-gray-200">$ COP (Colombian Peso)</span>
+                    </label>
+
+                    <label class="flex items-center">
+                        <input type="radio"
+                               name="currency"
+                               value="BDT"
+                               {{if eq .Currency "BDT"}}checked{{end}}
+                               hx-post="/api/settings/currency"
+                               hx-trigger="change"
+                               hx-vals='{"currency": "BDT"}'
+                               class="mr-2 text-primary focus:ring-primary">
+                        <span class="text-sm font-medium text-gray-700 dark:text-gray-200">৳ BDT (Bangladeshi Taka)</span>
                     </label>
                 </div>
 

--- a/templates/subscription-form.html
+++ b/templates/subscription-form.html
@@ -91,6 +91,7 @@
                     <option value="CHF" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "CHF"}}selected{{end}}{{end}}>Fr. CHF</option>
                     <option value="BRL" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "BRL"}}selected{{end}}{{end}}>R$ BRL</option>
                     <option value="COP" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "COP"}}selected{{end}}{{end}}>$ COP</option>
+                    <option value="BDT" {{if .Subscription}}{{if eq .Subscription.OriginalCurrency "BDT"}}selected{{end}}{{end}}>৳ BDT</option>
                 </select>
             </div>
 


### PR DESCRIPTION
## Summary

- Add Pushover notifications for high-cost alerts and renewal reminders.
- Add BDT (Bangladeshi Taka) currency support, including symbol and UI updates.
- Update README and AGENTS docs for the new features.

## Details

- New Pushover configuration section in Settings with test connection button.
- Pushover service integrated alongside existing email notifications.
- BDT added to supported currencies and subscription currency dropdown.

## Notes

- No breaking changes expected.
- Tested manually by creating subscriptions and verifying Pushover notifications.