### PR TITLE
v0.5.8 - API Partial Updates and Per-Subscription Reminders

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,65 @@
+# Release $ARGUMENTS
+
+Execute the SubTrackr release workflow for version $ARGUMENTS.
+
+## Pre-flight
+
+1. Verify you're on the correct branch: `git branch --show-current` should be `$ARGUMENTS`
+2. If not, create and checkout: `git checkout -b $ARGUMENTS`
+3. Run `gh release list --limit 1` to confirm the previous version
+
+## Track Work
+
+Create beads issues for each work item in this release:
+```bash
+bd create --title="Description (#GitHub-issue)" --type=feature --priority=2
+```
+
+## Build & Test
+
+1. Run `go build ./cmd/server` to verify compilation
+2. Run `gofmt -l .` to check formatting — fix any issues with `gofmt -w`
+3. Run `go vet ./...` to check for issues
+4. Run `go test ./...` to verify all tests pass
+
+## Create Draft Release
+
+```bash
+gh release create $ARGUMENTS --draft --title "$ARGUMENTS - Title" --notes "release notes here"
+```
+
+Write meaningful release notes covering what's new, bug fixes, and technical changes.
+
+## Commit & Push
+
+1. Stage changed files: `git add <specific files>`
+2. Commit with conventional format — NO AI attribution in commit messages:
+   ```
+   git commit -m "$ARGUMENTS - Release Title
+
+   - Change 1
+   - Change 2"
+   ```
+3. Push: `git push -u origin $ARGUMENTS`
+
+## Create Pull Request
+
+```bash
+gh pr create --title "$ARGUMENTS - Title" --body "summary and test plan, Closes #issues"
+```
+
+## Comment on Issues
+
+Notify issue reporters:
+```bash
+gh issue comment <number> --body "Fixed in PR #XX. Description."
+```
+
+## After Merge (user tells you to publish)
+
+```bash
+gh release edit $ARGUMENTS --draft=false
+gh release view $ARGUMENTS
+```
+
+The published tag triggers the Docker build workflow automatically.

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -23,6 +23,7 @@ func RunMigrations(db *gorm.DB) error {
 		migrateSubscriptionIcons,
 		migrateReminderTracking,
 		migrateCancellationReminderTracking,
+		migrateReminderEnabled,
 	}
 
 	for _, migration := range migrations {
@@ -43,7 +44,7 @@ func migrateCategoriesToDynamic(db *gorm.DB) error {
 	// Check if migration is needed by looking for the old category column
 	var count int64
 	db.Raw("SELECT COUNT(*) FROM pragma_table_info('subscriptions') WHERE name='category'").Scan(&count)
-	
+
 	if count == 0 {
 		// Migration already completed
 		return nil
@@ -55,7 +56,7 @@ func migrateCategoriesToDynamic(db *gorm.DB) error {
 	defaultCategories := []string{"Entertainment", "Productivity", "Storage", "Software", "Fitness", "Education", "Food", "Travel", "Business", "Other"}
 	var categories []models.Category
 	db.Find(&categories)
-	
+
 	if len(categories) == 0 {
 		for _, name := range defaultCategories {
 			db.Create(&models.Category{Name: name})
@@ -74,7 +75,7 @@ func migrateCategoriesToDynamic(db *gorm.DB) error {
 		ID       uint
 		Category string
 	}
-	
+
 	var oldSubs []OldSubscription
 	db.Table("subscriptions").Select("id, category").Scan(&oldSubs)
 
@@ -95,7 +96,7 @@ func migrateCategoriesToDynamic(db *gorm.DB) error {
 	// SQLite limitation: we can't drop the old category column
 	// The repository layer now handles both old and new schemas transparently
 	// This ensures backward compatibility without data loss
-	
+
 	log.Println("Migration completed: Categories converted to dynamic system")
 	return nil
 }
@@ -235,5 +236,28 @@ func migrateCancellationReminderTracking(db *gorm.DB) error {
 	}
 
 	log.Println("Migration completed: Cancellation reminder tracking fields added")
+	return nil
+}
+
+// migrateReminderEnabled adds per-subscription reminder toggle field
+func migrateReminderEnabled(db *gorm.DB) error {
+	// Check if column already exists
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM pragma_table_info('subscriptions') WHERE name = 'reminder_enabled'").Count(&count)
+
+	if count > 0 {
+		return nil
+	}
+
+	log.Println("Running migration: Adding per-subscription reminder_enabled field...")
+
+	if err := db.Exec("ALTER TABLE subscriptions ADD COLUMN reminder_enabled INTEGER DEFAULT 1").Error; err != nil {
+		log.Printf("Note: Could not add reminder_enabled column: %v", err)
+	}
+
+	// Set all existing subscriptions to enabled
+	db.Exec("UPDATE subscriptions SET reminder_enabled = 1 WHERE reminder_enabled IS NULL")
+
+	log.Println("Migration completed: reminder_enabled field added")
 	return nil
 }

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -100,15 +100,15 @@ func (h *SubscriptionHandler) enrichWithCurrencyConversion(subscriptions []model
 func (h *SubscriptionHandler) isHighCostWithCurrency(subscription *models.Subscription) bool {
 	threshold := h.settingsService.GetFloatSettingWithDefault("high_cost_threshold", 50.0)
 	displayCurrency := h.settingsService.GetCurrency()
-	
+
 	// Get monthly cost in subscription's original currency
 	monthlyCost := subscription.MonthlyCost()
-	
+
 	// If currencies match or conversion is disabled, compare directly
 	if subscription.OriginalCurrency == displayCurrency || !h.currencyService.IsEnabled() {
 		return monthlyCost > threshold
 	}
-	
+
 	// Convert monthly cost to display currency
 	convertedMonthlyCost, err := h.currencyService.ConvertAmount(monthlyCost, subscription.OriginalCurrency, displayCurrency)
 	if err != nil {
@@ -118,7 +118,7 @@ func (h *SubscriptionHandler) isHighCostWithCurrency(subscription *models.Subscr
 		log.Printf("Warning: Failed to convert currency for high-cost check (%s to %s): %v. Using direct comparison.", subscription.OriginalCurrency, displayCurrency, err)
 		return monthlyCost > threshold
 	}
-	
+
 	// Compare converted monthly cost against threshold
 	return convertedMonthlyCost > threshold
 }
@@ -322,19 +322,19 @@ func (h *SubscriptionHandler) Calendar(c *gin.Context) {
 	}
 
 	c.HTML(http.StatusOK, "calendar.html", gin.H{
-		"Title":                    "Calendar",
-		"CurrentPage":              "calendar",
-		"Year":                     year,
-		"Month":                    month,
-		"MonthName":                firstOfMonth.Format("January 2006"),
-		"EventsByDate":             template.JS(string(eventsJSON)),
-		"FirstOfMonth":             firstOfMonth,
-		"PrevMonth":                prevMonth,
-		"NextMonth":                nextMonth,
-		"CurrencySymbol":           h.settingsService.GetCurrencySymbol(),
-		"DarkMode":                 h.settingsService.IsDarkModeEnabled(),
-		"ICalSubscriptionEnabled":  icalSubscriptionEnabled,
-		"ICalSubscriptionURL":      icalSubscriptionURL,
+		"Title":                   "Calendar",
+		"CurrentPage":             "calendar",
+		"Year":                    year,
+		"Month":                   month,
+		"MonthName":               firstOfMonth.Format("January 2006"),
+		"EventsByDate":            template.JS(string(eventsJSON)),
+		"FirstOfMonth":            firstOfMonth,
+		"PrevMonth":               prevMonth,
+		"NextMonth":               nextMonth,
+		"CurrencySymbol":          h.settingsService.GetCurrencySymbol(),
+		"DarkMode":                h.settingsService.IsDarkModeEnabled(),
+		"ICalSubscriptionEnabled": icalSubscriptionEnabled,
+		"ICalSubscriptionURL":     icalSubscriptionURL,
 	})
 }
 
@@ -490,31 +490,31 @@ func (h *SubscriptionHandler) Settings(c *gin.Context) {
 	}
 
 	c.HTML(http.StatusOK, "settings.html", gin.H{
-		"Title":                     "Settings",
-		"CurrentPage":               "settings",
-		"Currency":                  h.settingsService.GetCurrency(),
-		"CurrencySymbol":            h.settingsService.GetCurrencySymbol(),
-		"RenewalReminders":          h.settingsService.GetBoolSettingWithDefault("renewal_reminders", false),
-		"HighCostAlerts":            h.settingsService.GetBoolSettingWithDefault("high_cost_alerts", true),
-		"PushoverConfig":            pushoverConfig,
-		"PushoverConfigured":        pushoverConfigured,
-		"HighCostThreshold":         h.settingsService.GetFloatSettingWithDefault("high_cost_threshold", 50.0),
-		"ReminderDays":              h.settingsService.GetIntSettingWithDefault("reminder_days", 7),
-		"CancellationReminders":     h.settingsService.GetBoolSettingWithDefault("cancellation_reminders", false),
-		"CancellationReminderDays":  h.settingsService.GetIntSettingWithDefault("cancellation_reminder_days", 7),
-		"DarkMode":                  h.settingsService.IsDarkModeEnabled(),
-		"Version":                   version.GetVersion(),
-		"SMTPConfig":                smtpConfig,
-		"SMTPConfigured":            smtpConfigured,
-		"AuthEnabled":               authEnabled,
-		"AuthUsername":              authUsername,
-		"ICalSubscriptionEnabled":   icalSubscriptionEnabled,
-		"ICalSubscriptionURL":       icalSubscriptionURL,
-		"BaseURL":                   h.settingsService.GetBaseURL(),
-		"Currencies":                service.GetAvailableCurrencies(),
-		"DateFormat":                h.settingsService.GetDateFormat(),
-		"WebhookConfig":             webhookConfig,
-		"WebhookConfigured":         webhookConfigured,
+		"Title":                    "Settings",
+		"CurrentPage":              "settings",
+		"Currency":                 h.settingsService.GetCurrency(),
+		"CurrencySymbol":           h.settingsService.GetCurrencySymbol(),
+		"RenewalReminders":         h.settingsService.GetBoolSettingWithDefault("renewal_reminders", false),
+		"HighCostAlerts":           h.settingsService.GetBoolSettingWithDefault("high_cost_alerts", true),
+		"PushoverConfig":           pushoverConfig,
+		"PushoverConfigured":       pushoverConfigured,
+		"HighCostThreshold":        h.settingsService.GetFloatSettingWithDefault("high_cost_threshold", 50.0),
+		"ReminderDays":             h.settingsService.GetIntSettingWithDefault("reminder_days", 7),
+		"CancellationReminders":    h.settingsService.GetBoolSettingWithDefault("cancellation_reminders", false),
+		"CancellationReminderDays": h.settingsService.GetIntSettingWithDefault("cancellation_reminder_days", 7),
+		"DarkMode":                 h.settingsService.IsDarkModeEnabled(),
+		"Version":                  version.GetVersion(),
+		"SMTPConfig":               smtpConfig,
+		"SMTPConfigured":           smtpConfigured,
+		"AuthEnabled":              authEnabled,
+		"AuthUsername":             authUsername,
+		"ICalSubscriptionEnabled":  icalSubscriptionEnabled,
+		"ICalSubscriptionURL":      icalSubscriptionURL,
+		"BaseURL":                  h.settingsService.GetBaseURL(),
+		"Currencies":               service.GetAvailableCurrencies(),
+		"DateFormat":               h.settingsService.GetDateFormat(),
+		"WebhookConfig":            webhookConfig,
+		"WebhookConfigured":        webhookConfigured,
 	})
 }
 
@@ -581,6 +581,14 @@ func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 	subscription.Notes = c.PostForm("notes")
 	subscription.Usage = c.PostForm("usage")
 
+	// Default reminders to enabled unless explicitly set to false
+	reminderVal := c.PostForm("reminder_enabled")
+	if reminderVal == "" {
+		subscription.ReminderEnabled = true
+	} else {
+		subscription.ReminderEnabled = reminderVal == "true"
+	}
+
 	// Parse cost
 	if costStr := c.PostForm("cost"); costStr != "" {
 		if cost, err := strconv.ParseFloat(costStr, 64); err == nil {
@@ -601,9 +609,9 @@ func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 	if err != nil {
 		// Log the error for debugging
 		log.Printf("Failed to create subscription: %v", err)
-		log.Printf("Subscription data: Name=%s, CategoryID=%d, Status=%s, Schedule=%s", 
+		log.Printf("Subscription data: Name=%s, CategoryID=%d, Status=%s, Schedule=%s",
 			subscription.Name, subscription.CategoryID, subscription.Status, subscription.Schedule)
-		
+
 		if c.GetHeader("HX-Request") != "" {
 			c.Header("HX-Retarget", "#form-errors")
 			c.HTML(http.StatusBadRequest, "form-errors.html", gin.H{
@@ -670,61 +678,91 @@ func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 		return
 	}
 
-	var subscription models.Subscription
+	// Fetch existing subscription first — only overwrite fields actually sent in the request
+	existing, err := h.service.GetByID(uint(id))
+	if err != nil || existing == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Subscription not found"})
+		return
+	}
 
-	// Parse form data (similar to CreateSubscription)
-	subscription.Name = c.PostForm("name")
-	// Parse category_id as uint
-	if categoryIDStr := c.PostForm("category_id"); categoryIDStr != "" {
-		if categoryID, err := strconv.ParseUint(categoryIDStr, 10, 32); err == nil {
-			subscription.CategoryID = uint(categoryID)
+	wasHighCost := h.isHighCostWithCurrency(existing)
+
+	// Merge form data: only update fields that were actually submitted
+	if val, ok := c.GetPostForm("name"); ok {
+		existing.Name = val
+	}
+	if val, ok := c.GetPostForm("category_id"); ok && val != "" {
+		if categoryID, err := strconv.ParseUint(val, 10, 32); err == nil {
+			existing.CategoryID = uint(categoryID)
 		}
 	}
-	subscription.Schedule = c.PostForm("schedule")
-	subscription.Status = c.PostForm("status")
-	subscription.OriginalCurrency = c.PostForm("original_currency")
-	if subscription.OriginalCurrency == "" {
-		subscription.OriginalCurrency = "USD" // Default to USD
+	if val, ok := c.GetPostForm("schedule"); ok {
+		existing.Schedule = val
 	}
-	subscription.PaymentMethod = c.PostForm("payment_method")
-	subscription.Account = c.PostForm("account")
-	subscription.URL = c.PostForm("url")
-	subscription.IconURL = c.PostForm("icon_url") // Allow manual icon URL override
-	subscription.Notes = c.PostForm("notes")
-	subscription.Usage = c.PostForm("usage")
+	if val, ok := c.GetPostForm("status"); ok {
+		existing.Status = val
+	}
+	if val, ok := c.GetPostForm("original_currency"); ok {
+		if val == "" {
+			existing.OriginalCurrency = "USD"
+		} else {
+			existing.OriginalCurrency = val
+		}
+	}
+	if val, ok := c.GetPostForm("payment_method"); ok {
+		existing.PaymentMethod = val
+	}
+	if val, ok := c.GetPostForm("account"); ok {
+		existing.Account = val
+	}
 
-	// Parse cost
-	if costStr := c.PostForm("cost"); costStr != "" {
-		if cost, err := strconv.ParseFloat(costStr, 64); err == nil {
-			subscription.Cost = cost
+	// Track URL changes for logo refresh
+	oldURL := existing.URL
+	if val, ok := c.GetPostForm("url"); ok {
+		existing.URL = val
+	}
+	urlChanged := existing.URL != oldURL
+
+	if val, ok := c.GetPostForm("icon_url"); ok && val != "" {
+		existing.IconURL = val
+	} else if urlChanged {
+		// URL changed but no explicit icon — re-fetch
+		existing.IconURL = ""
+	}
+
+	if val, ok := c.GetPostForm("notes"); ok {
+		existing.Notes = val
+	}
+	if val, ok := c.GetPostForm("usage"); ok {
+		existing.Usage = val
+	}
+	if val, ok := c.GetPostForm("reminder_enabled"); ok {
+		existing.ReminderEnabled = val == "true"
+	}
+	if val, ok := c.GetPostForm("cost"); ok && val != "" {
+		if cost, err := strconv.ParseFloat(val, 64); err == nil {
+			existing.Cost = cost
 		}
 	}
 
-	// Parse dates using helper function
-	// Always parse renewal date if provided; let service/model layer handle schedule change logic
-	subscription.StartDate = parseDatePtr(c.PostForm("start_date"))
-	subscription.RenewalDate = parseDatePtr(c.PostForm("renewal_date"))
-	subscription.CancellationDate = parseDatePtr(c.PostForm("cancellation_date"))
-
-	// Get the original subscription to check if it was high-cost before update
-	original, _ := h.service.GetByID(uint(id))
-	wasHighCost := original != nil && h.isHighCostWithCurrency(original)
-
-	// Check if URL changed - if so, we should fetch a new logo
-	urlChanged := original != nil && original.URL != subscription.URL
-
-	// Preserve existing IconURL if not explicitly set in form,
-	// but only when the URL has NOT changed (so we re-fetch on URL change)
-	if subscription.IconURL == "" && original != nil && !urlChanged {
-		subscription.IconURL = original.IconURL
+	// Parse dates — only update if the field was submitted
+	if val, ok := c.GetPostForm("start_date"); ok {
+		existing.StartDate = parseDatePtr(val)
+	}
+	if val, ok := c.GetPostForm("renewal_date"); ok {
+		existing.RenewalDate = parseDatePtr(val)
+	}
+	if val, ok := c.GetPostForm("cancellation_date"); ok {
+		existing.CancellationDate = parseDatePtr(val)
 	}
 
-	if urlChanged || (subscription.URL != "" && subscription.IconURL == "") {
-		h.fetchAndSetLogo(&subscription)
+	// Fetch new logo if URL changed or URL is set but no icon
+	if urlChanged || (existing.URL != "" && existing.IconURL == "") {
+		h.fetchAndSetLogo(existing)
 	}
 
 	// Update subscription
-	updated, err := h.service.Update(uint(id), &subscription)
+	updated, err := h.service.Update(uint(id), existing)
 	if err != nil {
 		c.Header("HX-Retarget", "#form-errors")
 		c.HTML(http.StatusBadRequest, "form-errors.html", gin.H{

--- a/internal/models/subscription.go
+++ b/internal/models/subscription.go
@@ -8,30 +8,31 @@ import (
 )
 
 type Subscription struct {
-	ID                     uint       `json:"id" gorm:"primaryKey"`
-	Name                   string     `json:"name" gorm:"not null" validate:"required"`
-	Cost                   float64    `json:"cost" gorm:"not null" validate:"required,gt=0"`
-	OriginalCurrency       string     `json:"original_currency" gorm:"size:3;default:'USD'"`
-	Schedule               string     `json:"schedule" gorm:"not null" validate:"required,oneof=Monthly Annual Weekly Daily Quarterly"`
-	Status                 string     `json:"status" gorm:"not null" validate:"required,oneof=Active Cancelled Paused Trial"`
-	CategoryID             uint       `json:"category_id"`
-	Category               Category   `json:"category" gorm:"foreignKey:CategoryID"`
-	PaymentMethod          string     `json:"payment_method" gorm:""`
-	Account                string     `json:"account" gorm:""`
-	StartDate              *time.Time `json:"start_date" gorm:""`
-	RenewalDate            *time.Time `json:"renewal_date" gorm:""`
-	CancellationDate       *time.Time `json:"cancellation_date" gorm:""`
-	URL                    string     `json:"url" gorm:""`
-	IconURL                string     `json:"icon_url" gorm:""` // URL to subscription icon/logo
-	Notes                  string     `json:"notes" gorm:""`
-	Usage                  string     `json:"usage" gorm:"" validate:"omitempty,oneof=High Medium Low None"`
-	DateCalculationVersion int        `json:"date_calculation_version" gorm:"default:1"`
-	LastReminderSent       *time.Time `json:"last_reminder_sent" gorm:""` // Tracks when the last reminder was sent
-	LastReminderRenewalDate *time.Time `json:"last_reminder_renewal_date" gorm:""` // Tracks which renewal date the last reminder was for
+	ID                           uint       `json:"id" gorm:"primaryKey"`
+	Name                         string     `json:"name" gorm:"not null" validate:"required"`
+	Cost                         float64    `json:"cost" gorm:"not null" validate:"required,gt=0"`
+	OriginalCurrency             string     `json:"original_currency" gorm:"size:3;default:'USD'"`
+	Schedule                     string     `json:"schedule" gorm:"not null" validate:"required,oneof=Monthly Annual Weekly Daily Quarterly"`
+	Status                       string     `json:"status" gorm:"not null" validate:"required,oneof=Active Cancelled Paused Trial"`
+	CategoryID                   uint       `json:"category_id"`
+	Category                     Category   `json:"category" gorm:"foreignKey:CategoryID"`
+	PaymentMethod                string     `json:"payment_method" gorm:""`
+	Account                      string     `json:"account" gorm:""`
+	StartDate                    *time.Time `json:"start_date" gorm:""`
+	RenewalDate                  *time.Time `json:"renewal_date" gorm:""`
+	CancellationDate             *time.Time `json:"cancellation_date" gorm:""`
+	URL                          string     `json:"url" gorm:""`
+	IconURL                      string     `json:"icon_url" gorm:""` // URL to subscription icon/logo
+	Notes                        string     `json:"notes" gorm:""`
+	Usage                        string     `json:"usage" gorm:"" validate:"omitempty,oneof=High Medium Low None"`
+	ReminderEnabled              bool       `json:"reminder_enabled" gorm:"default:true"`
+	DateCalculationVersion       int        `json:"date_calculation_version" gorm:"default:1"`
+	LastReminderSent             *time.Time `json:"last_reminder_sent" gorm:""`              // Tracks when the last reminder was sent
+	LastReminderRenewalDate      *time.Time `json:"last_reminder_renewal_date" gorm:""`      // Tracks which renewal date the last reminder was for
 	LastCancellationReminderSent *time.Time `json:"last_cancellation_reminder_sent" gorm:""` // Tracks when the last cancellation reminder was sent
 	LastCancellationReminderDate *time.Time `json:"last_cancellation_reminder_date" gorm:""` // Tracks which cancellation date the last reminder was for
-	CreatedAt              time.Time  `json:"created_at" gorm:"autoCreateTime"`
-	UpdatedAt              time.Time  `json:"updated_at" gorm:"autoUpdateTime"`
+	CreatedAt                    time.Time  `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt                    time.Time  `json:"updated_at" gorm:"autoUpdateTime"`
 }
 
 // AnnualCost calculates the annual cost based on schedule
@@ -99,7 +100,7 @@ func (s *Subscription) AfterFind(tx *gorm.DB) error {
 			// Renewal date has passed, calculate the next one
 			oldRenewalDate := s.RenewalDate
 			s.calculateNextRenewalDate()
-			
+
 			// Only update if the date actually changed to avoid unnecessary writes
 			if s.RenewalDate != nil && !s.RenewalDate.Equal(*oldRenewalDate) {
 				// Update only the renewal_date field using UpdateColumn to avoid triggering hooks
@@ -169,6 +170,7 @@ func (s *Subscription) BeforeUpdate(tx *gorm.DB) error {
 //   - All existing subscriptions use V1 unless explicitly migrated
 //   - Uses standard Go time.AddDate() which may cause edge cases
 //   - Example: Jan 31 + 1 month = Mar 3 (due to Feb having 28 days)
+//
 // - V2: Enhanced calculation using Carbon library for robust date arithmetic
 //   - Must be explicitly set via DateCalculationVersion = 2
 //   - Uses Carbon's AddMonthsNoOverflow/AddYearsNoOverflow for better handling

--- a/internal/repository/subscription.go
+++ b/internal/repository/subscription.go
@@ -9,7 +9,7 @@ import (
 )
 
 type SubscriptionRepository struct {
-	db *gorm.DB
+	db              *gorm.DB
 	hasLegacyColumn *bool
 }
 
@@ -21,7 +21,7 @@ func (r *SubscriptionRepository) checkLegacyColumn() bool {
 	if r.hasLegacyColumn != nil {
 		return *r.hasLegacyColumn
 	}
-	
+
 	var exists bool
 	r.db.Raw("SELECT COUNT(*) > 0 FROM pragma_table_info('subscriptions') WHERE name='category'").Scan(&exists)
 	r.hasLegacyColumn = &exists
@@ -31,7 +31,7 @@ func (r *SubscriptionRepository) checkLegacyColumn() bool {
 func (r *SubscriptionRepository) Create(subscription *models.Subscription) (*models.Subscription, error) {
 	// Check if the old category column exists (for legacy schema support)
 	columnExists := r.checkLegacyColumn()
-	
+
 	if columnExists && subscription.CategoryID > 0 {
 		// For legacy schema, we need to populate the old category column
 		var category models.Category
@@ -51,11 +51,11 @@ func (r *SubscriptionRepository) Create(subscription *models.Subscription) (*mod
 					subscription.CancellationDate, subscription.URL,
 					subscription.Notes, subscription.Usage, subscription.DateCalculationVersion,
 					time.Now(), time.Now())
-				
+
 				if result.Error != nil {
 					return result.Error
 				}
-				
+
 				// Get the last inserted ID within the transaction
 				var lastID int64
 				if err := tx.Raw("SELECT last_insert_rowid()").Scan(&lastID).Error; err != nil {
@@ -64,15 +64,15 @@ func (r *SubscriptionRepository) Create(subscription *models.Subscription) (*mod
 				subscription.ID = uint(lastID)
 				return nil
 			})
-			
+
 			if err != nil {
 				return nil, err
 			}
-			
+
 			return subscription, nil
 		}
 	}
-	
+
 	// Normal creation for migrated schema
 	if err := r.db.Create(subscription).Error; err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func (r *SubscriptionRepository) GetAllSorted(sortBy, order string) ([]models.Su
 
 	// Build order clause
 	orderClause := sortColumn + " " + strings.ToUpper(order)
-	
+
 	// Special handling for category (requires join)
 	if sortBy == "category" {
 		query = query.Joins("LEFT JOIN categories ON subscriptions.category_id = categories.id")
@@ -166,6 +166,7 @@ func (r *SubscriptionRepository) Update(id uint, subscription *models.Subscripti
 	existing.IconURL = subscription.IconURL
 	existing.Notes = subscription.Notes
 	existing.Usage = subscription.Usage
+	existing.ReminderEnabled = subscription.ReminderEnabled
 
 	if columnExists && subscription.CategoryID > 0 {
 		// For legacy schema, we need to update the old category column too
@@ -173,25 +174,26 @@ func (r *SubscriptionRepository) Update(id uint, subscription *models.Subscripti
 		if err := r.db.First(&category, subscription.CategoryID).Error; err == nil {
 			// We need to manually set the category name for legacy schema
 			updates := map[string]interface{}{
-				"name":               existing.Name,
-				"cost":               existing.Cost,
-				"schedule":           existing.Schedule,
-				"status":             existing.Status,
-				"category_id":        existing.CategoryID,
-				"category":           category.Name,
-				"original_currency":  existing.OriginalCurrency,
-				"payment_method":     existing.PaymentMethod,
-				"account":            existing.Account,
-				"start_date":         existing.StartDate,
-				"renewal_date":                existing.RenewalDate,
-				"cancellation_date":           existing.CancellationDate,
-				"url":                         existing.URL,
-				"icon_url":                    existing.IconURL,
-				"notes":                       existing.Notes,
-				"usage":                       existing.Usage,
-				"last_reminder_sent":          existing.LastReminderSent,
-				"last_reminder_renewal_date":  existing.LastReminderRenewalDate,
-				"updated_at":         time.Now(),
+				"name":                       existing.Name,
+				"cost":                       existing.Cost,
+				"schedule":                   existing.Schedule,
+				"status":                     existing.Status,
+				"category_id":                existing.CategoryID,
+				"category":                   category.Name,
+				"original_currency":          existing.OriginalCurrency,
+				"payment_method":             existing.PaymentMethod,
+				"account":                    existing.Account,
+				"start_date":                 existing.StartDate,
+				"renewal_date":               existing.RenewalDate,
+				"cancellation_date":          existing.CancellationDate,
+				"url":                        existing.URL,
+				"icon_url":                   existing.IconURL,
+				"notes":                      existing.Notes,
+				"usage":                      existing.Usage,
+				"last_reminder_sent":         existing.LastReminderSent,
+				"last_reminder_renewal_date": existing.LastReminderRenewalDate,
+				"reminder_enabled":           existing.ReminderEnabled,
+				"updated_at":                 time.Now(),
 			}
 			if err := r.db.Model(&existing).Where("id = ?", id).Updates(updates).Error; err != nil {
 				return nil, err

--- a/internal/service/renewal_reminder_test.go
+++ b/internal/service/renewal_reminder_test.go
@@ -40,8 +40,8 @@ func TestSubscriptionService_GetSubscriptionsNeedingReminders(t *testing.T) {
 	now := time.Now()
 
 	tests := []struct {
-		name         string
-		reminderDays int
+		name          string
+		reminderDays  int
 		subscriptions []models.Subscription
 		expectedCount int
 		description   string
@@ -406,17 +406,17 @@ func TestSubscriptionService_GetSubscriptionsNeedingReminders_DuplicatePreventio
 	subscriptionService := NewSubscriptionService(subscriptionRepo, categoryService)
 
 	now := time.Now()
-	renewalDate := now.AddDate(0, 0, 5) // 5 days from now
+	renewalDate := now.AddDate(0, 0, 5)       // 5 days from now
 	lastReminderDate := now.AddDate(0, 0, -1) // 1 day ago
 
 	// Create subscription with reminder already sent for this renewal date
 	sub := &models.Subscription{
-		Name:                   "Test Subscription",
-		Cost:                   10.00,
-		Schedule:               "Monthly",
-		Status:                 "Active",
-		RenewalDate:            &renewalDate,
-		LastReminderSent:       &lastReminderDate,
+		Name:                    "Test Subscription",
+		Cost:                    10.00,
+		Schedule:                "Monthly",
+		Status:                  "Active",
+		RenewalDate:             &renewalDate,
+		LastReminderSent:        &lastReminderDate,
 		LastReminderRenewalDate: &renewalDate, // Same as current renewal date
 	}
 	err := db.Create(sub).Error
@@ -450,8 +450,54 @@ func TestSubscriptionService_GetSubscriptionsNeedingReminders_DuplicatePreventio
 	assert.Equal(t, 1, len(result), "Should find subscription when renewal date changes")
 }
 
+func TestSubscriptionService_GetSubscriptionsNeedingReminders_ReminderDisabled(t *testing.T) {
+	db := setupRenewalReminderTestDB(t)
+	subscriptionRepo := repository.NewSubscriptionRepository(db)
+	categoryRepo := repository.NewCategoryRepository(db)
+	categoryService := NewCategoryService(categoryRepo)
+	subscriptionService := NewSubscriptionService(subscriptionRepo, categoryService)
+
+	now := time.Now()
+	renewalDate := now.AddDate(0, 0, 5)
+
+	// Create subscription with reminders disabled
+	sub := &models.Subscription{
+		Name:            "No Reminders Sub",
+		Cost:            10.00,
+		Schedule:        "Monthly",
+		Status:          "Active",
+		RenewalDate:     &renewalDate,
+		ReminderEnabled: true,
+	}
+	err := db.Create(sub).Error
+	assert.NoError(t, err)
+	// Explicitly disable after create (GORM skips false for default:true fields)
+	db.Model(sub).Update("reminder_enabled", false)
+
+	// Should not be included in reminders
+	result, err := subscriptionService.GetSubscriptionsNeedingReminders(7)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(result), "Should not find subscription with reminders disabled")
+
+	// Create subscription with reminders enabled
+	sub2 := &models.Subscription{
+		Name:            "With Reminders Sub",
+		Cost:            20.00,
+		Schedule:        "Monthly",
+		Status:          "Active",
+		RenewalDate:     &renewalDate,
+		ReminderEnabled: true,
+	}
+	err = db.Create(sub2).Error
+	assert.NoError(t, err)
+
+	// Should find only the enabled one
+	result, err = subscriptionService.GetSubscriptionsNeedingReminders(7)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result), "Should only find subscription with reminders enabled")
+}
+
 // Helper function to create time pointer
 func timePtr(t time.Time) *time.Time {
 	return &t
 }
-

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -115,6 +115,9 @@ func (s *SubscriptionService) GetSubscriptionsNeedingReminders(reminderDays int)
 		if sub.RenewalDate == nil {
 			continue
 		}
+		if !sub.ReminderEnabled {
+			continue
+		}
 
 		// Calculate days until renewal using proper date arithmetic
 		// Use time.Until for more accurate calculation (handles timezone differences better)
@@ -156,6 +159,9 @@ func (s *SubscriptionService) GetSubscriptionsNeedingCancellationReminders(remin
 	for i := range subscriptions {
 		sub := &subscriptions[i]
 		if sub.CancellationDate == nil {
+			continue
+		}
+		if !sub.ReminderEnabled {
 			continue
 		}
 

--- a/templates/subscription-form.html
+++ b/templates/subscription-form.html
@@ -201,6 +201,18 @@
                           placeholder="Additional notes about this subscription"
                           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition-colors duration-150">{{if .Subscription}}{{.Subscription.Notes}}{{end}}</textarea>
             </div>
+
+            <!-- Reminder Toggle -->
+            <div class="md:col-span-2">
+                <label class="flex items-center space-x-3 cursor-pointer">
+                    <input type="hidden" name="reminder_enabled" value="false">
+                    <input type="checkbox" name="reminder_enabled" value="true"
+                           {{if .IsEdit}}{{if .Subscription.ReminderEnabled}}checked{{end}}{{else}}checked{{end}}
+                           class="w-4 h-4 text-primary bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 rounded focus:ring-primary focus:ring-2 transition-colors duration-150">
+                    <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Send renewal reminders for this subscription</span>
+                </label>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400 ml-7">Disable for autopay subscriptions that don't need reminders</p>
+            </div>
         </div>
 
         <div class="flex justify-end space-x-3 mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">

--- a/templates/subscription-list.html
+++ b/templates/subscription-list.html
@@ -128,7 +128,7 @@
                         <div class="w-3 h-3 {{if eq .Status "Active"}}bg-success{{else if eq .Status "Cancelled"}}bg-danger{{else}}bg-warning{{end}} rounded-full mr-3"></div>
                         {{end}}
                         <div>
-                            <div class="text-sm font-medium text-gray-900 dark:text-white">{{.Name}}</div>
+                            <div class="text-sm font-medium text-gray-900 dark:text-white">{{.Name}}{{if not .ReminderEnabled}} <span title="Reminders disabled" class="inline-flex text-gray-400 dark:text-gray-500"><svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/><line x1="3" y1="3" x2="21" y2="21" stroke-width="2" stroke-linecap="round"/></svg></span>{{end}}</div>
                             {{if .URL}}
                             <a href="{{.URL}}" target="_blank" class="text-xs text-primary hover:text-primary/80 dark:text-primary-light">{{.URL}}</a>
                             {{end}}


### PR DESCRIPTION
## Summary
- **Fix #105**: PUT /api/subscriptions/:id now merges partial updates instead of wiping omitted fields
- **Fix #104**: Per-subscription reminder toggle — users can disable reminders for individual subscriptions
- Added `/release` Claude Code slash command for release workflow

## Changes
- Refactored `UpdateSubscription` handler to use `GetPostForm()` for field-level merge
- Added `ReminderEnabled` bool field to Subscription model (default: true)
- Added DB migration for `reminder_enabled` column
- Added form toggle in subscription edit form
- Added bell-slash indicator in subscription list
- Service layer filters out disabled subscriptions from reminder checks
- Test coverage for reminder filtering

## Test Plan
- [x] `go test ./...` passes
- [ ] Manual: `curl -X PUT /api/subscriptions/1 -d "status=Cancelled"` preserves other fields
- [ ] Manual: Edit subscription via form — all fields persist
- [ ] Manual: New subscription has reminder toggle checked by default
- [ ] Manual: Disable reminders on a subscription — bell-slash icon appears
- [ ] Browser: Full form edit flow works correctly

Closes #104
Closes #105