### PR TITLE
v0.6.1 - Fix login page crash from missing Lang on auth templates (#113)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -94,7 +94,7 @@ func main() {
 	subscriptionHandler := handlers.NewSubscriptionHandler(subscriptionService, settingsService, currencyService, emailService, pushoverService, webhookService, logoService, categoryService, tagService, i18nCatalog)
 	settingsHandler := handlers.NewSettingsHandler(settingsService)
 	categoryHandler := handlers.NewCategoryHandler(categoryService)
-	authHandler := handlers.NewAuthHandler(settingsService, sessionService, emailService)
+	authHandler := handlers.NewAuthHandler(settingsService, sessionService, emailService, i18nCatalog)
 
 	// Setup Gin router
 	if cfg.Environment == "production" {
@@ -137,8 +137,9 @@ func main() {
 		"fmtTime": func(t time.Time, format string) string {
 			return t.Format(format)
 		},
-		"t": func(lang, key string) string {
-			return i18nCatalog.T(lang, key)
+		"t": func(lang interface{}, key string) string {
+			langStr, _ := lang.(string)
+			return i18nCatalog.T(langStr, key)
 		},
 	})
 
@@ -217,8 +218,9 @@ func loadTemplates(catalog *i18n.Catalog) *template.Template {
 
 	// Add template functions
 	tmpl.Funcs(template.FuncMap{
-		"t": func(lang, key string) string {
-			return catalog.T(lang, key)
+		"t": func(lang interface{}, key string) string {
+			langStr, _ := lang.(string)
+			return catalog.T(langStr, key)
 		},
 		"add": func(a, b float64) float64 { return a + b },
 		"sub": func(a, b float64) float64 { return a - b },

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"subtrackr/internal/i18n"
 	"subtrackr/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -15,14 +16,26 @@ type AuthHandler struct {
 	settingsService *service.SettingsService
 	sessionService  *service.SessionService
 	emailService    *service.EmailService
+	i18nCatalog     *i18n.Catalog
 }
 
-func NewAuthHandler(settingsService *service.SettingsService, sessionService *service.SessionService, emailService *service.EmailService) *AuthHandler {
+func NewAuthHandler(settingsService *service.SettingsService, sessionService *service.SessionService, emailService *service.EmailService, i18nCatalog *i18n.Catalog) *AuthHandler {
 	return &AuthHandler{
 		settingsService: settingsService,
 		sessionService:  sessionService,
 		emailService:    emailService,
+		i18nCatalog:     i18nCatalog,
 	}
+}
+
+// activeLang resolves the user-preferred language code, defaulting to "en" when unset
+// or when the requested language has no loaded translations.
+func (h *AuthHandler) activeLang() string {
+	lang := h.settingsService.GetStringSettingWithDefault("lang", "en")
+	if h.i18nCatalog != nil && !h.i18nCatalog.HasLanguage(lang) {
+		return "en"
+	}
+	return lang
 }
 
 // isValidRedirect validates that a redirect URL is safe (relative URL only)
@@ -56,6 +69,7 @@ func (h *AuthHandler) ShowLoginPage(c *gin.Context) {
 	c.HTML(http.StatusOK, "login.html", gin.H{
 		"Redirect": redirect,
 		"Error":    c.Query("error"),
+		"Lang":     h.activeLang(),
 	})
 }
 
@@ -120,7 +134,9 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 // ShowForgotPasswordPage displays the forgot password page
 func (h *AuthHandler) ShowForgotPasswordPage(c *gin.Context) {
-	c.HTML(http.StatusOK, "forgot-password.html", gin.H{})
+	c.HTML(http.StatusOK, "forgot-password.html", gin.H{
+		"Lang": h.activeLang(),
+	})
 }
 
 // ForgotPassword handles forgot password request
@@ -176,6 +192,7 @@ func (h *AuthHandler) ShowResetPasswordPage(c *gin.Context) {
 	if token == "" {
 		c.HTML(http.StatusBadRequest, "reset-password.html", gin.H{
 			"Error": "Invalid reset token",
+			"Lang":  h.activeLang(),
 		})
 		return
 	}
@@ -184,12 +201,14 @@ func (h *AuthHandler) ShowResetPasswordPage(c *gin.Context) {
 	if err := h.settingsService.ValidateResetToken(token); err != nil {
 		c.HTML(http.StatusBadRequest, "reset-password.html", gin.H{
 			"Error": "Invalid or expired reset token",
+			"Lang":  h.activeLang(),
 		})
 		return
 	}
 
 	c.HTML(http.StatusOK, "reset-password.html", gin.H{
 		"Token": token,
+		"Lang":  h.activeLang(),
 	})
 }
 

--- a/internal/handlers/auth_test.go
+++ b/internal/handlers/auth_test.go
@@ -1,0 +1,154 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"subtrackr/internal/i18n"
+	"subtrackr/internal/models"
+	"subtrackr/internal/repository"
+	"subtrackr/internal/service"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// repoRoot walks up from the test working directory to locate the project root
+// (the directory containing go.mod). Tests run with cwd == package dir, so the
+// templates and locales need an absolute path.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate go.mod from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+func newAuthTestRouter(t *testing.T) (*gin.Engine, *AuthHandler) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	root := repoRoot(t)
+
+	catalog := i18n.NewCatalog()
+	require.NoError(t, catalog.LoadDir(filepath.Join(root, "web", "locales")))
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Settings{}))
+
+	settingsService := service.NewSettingsService(repository.NewSettingsRepository(db))
+	sessionService := service.NewSessionService("test-secret-key-for-auth-handler-test")
+
+	authHandler := NewAuthHandler(settingsService, sessionService, nil, catalog)
+
+	router := gin.New()
+	tFunc := func(lang interface{}, key string) string {
+		langStr, _ := lang.(string)
+		return catalog.T(langStr, key)
+	}
+	router.SetFuncMap(template.FuncMap{"t": tFunc})
+	// Load only the auth-related templates to avoid pulling in templates that
+	// reference other helpers (div/mul/etc.) we don't need here.
+	router.LoadHTMLFiles(
+		filepath.Join(root, "templates", "login.html"),
+		filepath.Join(root, "templates", "forgot-password.html"),
+		filepath.Join(root, "templates", "reset-password.html"),
+	)
+
+	router.GET("/login", authHandler.ShowLoginPage)
+	router.GET("/forgot-password", authHandler.ShowForgotPasswordPage)
+	router.GET("/reset-password", authHandler.ShowResetPasswordPage)
+
+	return router, authHandler
+}
+
+// TestShowLoginPage_RendersWithoutLangError reproduces issue #113 — before the
+// fix, the login template's {{t .Lang "..."}} crashed because the handler did
+// not pass Lang in the template context.
+func TestShowLoginPage_RendersWithoutLangError(t *testing.T) {
+	router, _ := newAuthTestRouter(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.NotContains(t, body, "template:")
+	assert.NotContains(t, body, "invalid value")
+	// English fallback content from the auth.sign_in_title key.
+	assert.Contains(t, body, "Sign")
+}
+
+func TestShowForgotPasswordPage_RendersWithoutLangError(t *testing.T) {
+	router, _ := newAuthTestRouter(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/forgot-password", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, w.Body.String(), "invalid value")
+}
+
+func TestShowResetPasswordPage_MissingTokenRendersWithoutLangError(t *testing.T) {
+	router, _ := newAuthTestRouter(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/reset-password", nil)
+	router.ServeHTTP(w, req)
+
+	// Token missing → 400, but template must still render without a Lang error.
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.NotContains(t, w.Body.String(), "invalid value")
+}
+
+// TestTFunc_HandlesNonStringLang locks in the defensive coercion in the
+// template's t function so missing/nil .Lang values fall back to English
+// instead of crashing the render.
+func TestTFunc_HandlesNonStringLang(t *testing.T) {
+	root := repoRoot(t)
+	catalog := i18n.NewCatalog()
+	require.NoError(t, catalog.LoadDir(filepath.Join(root, "web", "locales")))
+
+	tFunc := func(lang interface{}, key string) string {
+		langStr, _ := lang.(string)
+		return catalog.T(langStr, key)
+	}
+
+	tmpl := template.Must(template.New("t").Funcs(template.FuncMap{"t": tFunc}).Parse(`{{t .Lang "auth.sign_in_title"}}`))
+
+	cases := []struct {
+		name string
+		data map[string]interface{}
+	}{
+		{name: "missing Lang", data: map[string]interface{}{}},
+		{name: "nil Lang", data: map[string]interface{}{"Lang": nil}},
+		{name: "empty Lang", data: map[string]interface{}{"Lang": ""}},
+		{name: "english Lang", data: map[string]interface{}{"Lang": "en"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sb strings.Builder
+			err := tmpl.Execute(&sb, tc.data)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, sb.String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #113. After upgrading to v0.6.0, the login page crashed with:

```
template: login.html:21:61: executing "login.html" at <.Lang>: invalid value; expected string
```

`login.html`, `forgot-password.html`, and `reset-password.html` all use `{{t .Lang "..."}}` for i18n, but the auth handler never populated `Lang` in the template context. Go's `html/template` rejected the call because the `t` func required a `string` and `.Lang` was undefined — leaving users stuck on the login screen.

## Changes

- **`internal/handlers/auth.go`** — `AuthHandler` now takes the i18n catalog and exposes an `activeLang()` helper (mirroring `SubscriptionHandler`). All three auth template renders pass `Lang: h.activeLang()`, honoring the user's language preference and falling back to `"en"` when unset or unknown.
- **`cmd/server/main.go`** — the `t` template function now accepts `interface{}` for the lang argument and coerces to `string`. Defense in depth so any future template render that forgets to pass `Lang` falls back to English instead of crashing the page.
- **`internal/handlers/auth_test.go`** — new tests covering:
  - `/login`, `/forgot-password`, `/reset-password` render without template errors
  - the `t` function gracefully handles missing/nil/empty/string lang values

## Test Plan

- [ ] Enable authentication and confirm `/login` renders normally (no 500, no template error in logs)
- [ ] `/forgot-password` and `/reset-password` render normally
- [ ] Change preferred language in Settings, log out, confirm login page reflects the chosen language
- [ ] Existing translations on dashboard/subscriptions/etc. still work
- [ ] `go test ./...` passes

Closes #113

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash introduced in v0.6.0 where the auth handler did not pass `Lang` in the template data for login, forgot-password, and reset-password pages, causing `{{t .Lang "..."}}` calls to fail with "invalid value; expected string". The fix is applied at two levels: the handler now resolves and passes a `Lang` value on every code path, and the `t` template function now accepts `interface{}` for the lang argument so a missing `Lang` field silently falls back to English instead of aborting the render.

- All three auth page handlers (`ShowLoginPage`, `ShowForgotPasswordPage`, `ShowResetPasswordPage`) now call `activeLang()` and include the result in the template context; the `activeLang` helper reads the global `lang` setting and validates it against the loaded catalog, defaulting to `"en"` when unset or unrecognized.
- The `"t"` template function signature is widened to `func(lang interface{}, key string) string` in both `main.go` registration sites, using a blank-ok type assertion so a `nil` or absent `.Lang` coerces to `""` and falls through to the English fallback in `Catalog.T`.
- A new `auth_test.go` reproduces the original crash by rendering all three pages end-to-end and asserting no template errors, plus a table-driven unit test covering nil, missing, empty, and valid lang values for the `t` function.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to fixing a template-render crash on auth pages and adding a defensive fallback in the t function; existing authenticated flows are untouched.

All three auth pages now pass Lang on every render branch (including both error branches in ShowResetPasswordPage), the error/success partial templates were confirmed to not use t .Lang so they need no change, and the new tests directly exercise the crash scenario. The activeLang helper correctly guards against an unknown language code even when the catalog is swapped at runtime.

No files require special attention; the changes are minimal and the new test suite covers the repaired paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/server/main.go | Passes i18nCatalog to NewAuthHandler and changes the "t" template function signature to accept interface{} for lang, coercing to string with a safe type assertion in both registration sites. |
| internal/handlers/auth.go | Adds i18nCatalog to AuthHandler, introduces activeLang() helper that reads the global lang setting with "en" fallback, and passes "Lang" in template data for all three auth page renders (login, forgot-password, reset-password in all error/success branches). |
| internal/handlers/auth_test.go | New test file that reproduces issue #113 by rendering all three auth pages end-to-end and asserting no template errors, plus a table-driven unit test for the t function with nil/missing/empty lang values. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP Request auth page] --> B[AuthHandler method]
    B --> C[activeLang called]
    C --> D[settingsService.GetStringSettingWithDefault]
    D --> E{i18nCatalog nil?}
    E -- nil --> G[return lang as-is]
    E -- not nil --> F{HasLanguage lang?}
    F -- Yes --> G
    F -- No --> H[return 'en']
    G --> I[gin.H with Lang key]
    H --> I
    I --> J[c.HTML template render]
    J --> K[t function called with lang as interface]
    K --> L[type assert to string, empty if nil/missing]
    L --> M[Catalog.T called]
    M --> N{lang found in catalog?}
    N -- Yes --> O[Return translation]
    N -- No --> P[Fallback to English translation]
    P --> O
```

<sub>Reviews (1): Last reviewed commit: ["v0.6.1 - Fix login page crash from missi..."](https://github.com/bscott/subtrackr/commit/c6f7a17275e75f64f468493368fd16eca60395dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32521073)</sub>

<!-- /greptile_comment -->