### PR TITLE
v0.6.3 - Fix reminder toggle when editing subscriptions

### DIFF
--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -635,12 +635,14 @@ func (h *SubscriptionHandler) CreateSubscription(c *gin.Context) {
 	subscription.Notes = c.PostForm("notes")
 	subscription.Usage = c.PostForm("usage")
 
-	// Default reminders to enabled unless explicitly set to false
-	reminderVal := c.PostForm("reminder_enabled")
-	if reminderVal == "" {
+	// Default reminders to enabled unless explicitly set to false.
+	// The form submits a hidden "false" before the checkbox's "true", so use
+	// the last value (Gin's PostForm returns the first, which is always "false").
+	reminderVals := c.PostFormArray("reminder_enabled")
+	if len(reminderVals) == 0 {
 		subscription.ReminderEnabled = true
 	} else {
-		subscription.ReminderEnabled = reminderVal == "true"
+		subscription.ReminderEnabled = reminderVals[len(reminderVals)-1] == "true"
 	}
 
 	// Parse cost
@@ -840,8 +842,10 @@ func (h *SubscriptionHandler) UpdateSubscription(c *gin.Context) {
 	if val, ok := c.GetPostForm("usage"); ok {
 		existing.Usage = val
 	}
-	if val, ok := c.GetPostForm("reminder_enabled"); ok {
-		existing.ReminderEnabled = val == "true"
+	// The form submits a hidden "false" before the checkbox's "true", so use
+	// the last value (Gin's GetPostForm returns the first, which is always "false").
+	if vals := c.PostFormArray("reminder_enabled"); len(vals) > 0 {
+		existing.ReminderEnabled = vals[len(vals)-1] == "true"
 	}
 	if val, ok := c.GetPostForm("cost"); ok && val != "" {
 		if cost, err := strconv.ParseFloat(val, 64); err == nil {

--- a/internal/handlers/subscription_reminder_test.go
+++ b/internal/handlers/subscription_reminder_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"subtrackr/internal/database"
+	"subtrackr/internal/models"
+	"subtrackr/internal/repository"
+	"subtrackr/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newReminderTestRouter wires the minimal set of services needed to exercise
+// UpdateSubscription's reminder-toggle handling against an in-memory database.
+func newReminderTestRouter(t *testing.T) (*gin.Engine, *service.SubscriptionService) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, database.RunMigrations(db))
+
+	subscriptionRepo := repository.NewSubscriptionRepository(db)
+	categoryService := service.NewCategoryService(repository.NewCategoryRepository(db))
+	subscriptionService := service.NewSubscriptionService(subscriptionRepo, categoryService)
+	settingsService := service.NewSettingsService(repository.NewSettingsRepository(db))
+	currencyService := service.NewCurrencyService(repository.NewExchangeRateRepository(db))
+
+	handler := NewSubscriptionHandler(
+		subscriptionService,
+		settingsService,
+		currencyService,
+		nil, // emailService — only used on high-cost transition
+		nil, // pushoverService
+		nil, // webhookService
+		nil, // logoService — only used when a URL is set
+		categoryService,
+		nil, // tagService — only used when tags are submitted
+		nil, // i18nCatalog
+	)
+
+	router := gin.New()
+	router.POST("/subscriptions/:id", handler.UpdateSubscription)
+
+	return router, subscriptionService
+}
+
+// TestUpdateSubscription_ReminderToggle reproduces issue #119. The edit form
+// submits a hidden reminder_enabled=false immediately before the checkbox's
+// reminder_enabled=true. Gin's GetPostForm returns the *first* value, so the
+// handler must read the last value of the array for the checkbox to take effect.
+func TestUpdateSubscription_ReminderToggle(t *testing.T) {
+	tests := []struct {
+		name     string
+		formBody string // raw body, mirroring what the browser submits
+		start    bool   // initial ReminderEnabled state
+		want     bool   // expected state after the update
+	}{
+		{
+			name:     "enable when checkbox checked (hidden false + true)",
+			formBody: "reminder_enabled=false&reminder_enabled=true",
+			start:    false,
+			want:     true,
+		},
+		{
+			name:     "disable when checkbox unchecked (hidden false only)",
+			formBody: "reminder_enabled=false",
+			start:    true,
+			want:     false,
+		},
+		{
+			name:     "field absent leaves value unchanged",
+			formBody: "name=Netflix",
+			start:    true,
+			want:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			router, svc := newReminderTestRouter(t)
+
+			created, err := svc.Create(&models.Subscription{
+				Name:            "Netflix",
+				Cost:            9.99,
+				Schedule:        "Monthly",
+				Status:          "Active",
+				ReminderEnabled: tc.start,
+			})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/subscriptions/"+strconv.FormatUint(uint64(created.ID), 10),
+				strings.NewReader(tc.formBody),
+			)
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+			updated, err := svc.GetByID(created.ID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, updated.ReminderEnabled)
+		})
+	}
+}

--- a/templates/subscriptions.html
+++ b/templates/subscriptions.html
@@ -318,7 +318,7 @@
                             <div class="w-3 h-3 {{if eq .Status "Active"}}bg-success{{else if eq .Status "Cancelled"}}bg-danger{{else}}bg-warning{{end}} rounded-full mr-3"></div>
                             {{end}}
                             <div>
-                                <div class="text-sm font-medium text-gray-900 dark:text-white">{{.Name}}</div>
+                                <div class="text-sm font-medium text-gray-900 dark:text-white">{{.Name}}{{if not .ReminderEnabled}} <span title="{{t $.Lang "common.reminders_disabled"}}" class="inline-flex text-gray-400 dark:text-gray-500"><svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/><line x1="3" y1="3" x2="21" y2="21" stroke-width="2" stroke-linecap="round"/></svg></span>{{end}}</div>
                                 {{if .Label}}
                                 <div class="text-xs text-gray-600 dark:text-gray-400 italic">{{.Label}}</div>
                                 {{end}}


### PR DESCRIPTION
## Summary

Fixes #119 — enabling/disabling reminders while editing a subscription is now persisted correctly.

The edit form submits a hidden `reminder_enabled=false` immediately before the checkbox's `reminder_enabled=true`. Gin's `PostForm`/`GetPostForm` return the **first** value of a repeated field, so the checkbox was always ignored and reminders were saved as disabled regardless of the toggle.

## Changes

- **`internal/handlers/subscription.go`** — `CreateSubscription` and `UpdateSubscription` now read the **last** value of `reminder_enabled` via `PostFormArray`, so the standard hidden-input + checkbox pattern works in every case (enable, disable, field-absent).
- **`templates/subscriptions.html`** — render the "reminders disabled" mute icon on the full Subscriptions page, matching the htmx list partial (previously it only appeared after an htmx refresh).
- **`internal/handlers/subscription_reminder_test.go`** — regression test covering enable/disable/absent cases.

## Test Plan

- [x] `go test ./...` passes
- [x] Unit test fails without the fix, passes with it
- [x] End-to-end browser test (Playwright) against the running app: enable/disable round-trips persist correctly and the mute icon reflects state — 6/6 checks
- [ ] Manual verification in the app

Closes #119