### PR TITLE
feat: add Wallos JSON importer (Closes #65)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -426,6 +426,7 @@ func setupRoutes(router *gin.Engine, handler *handlers.SubscriptionHandler, sett
 		api.GET("/export/ical", handler.ExportICal)
 		api.GET("/backup", handler.BackupData)
 		api.POST("/restore", handler.RestoreData)
+		api.POST("/import/wallos", handler.ImportWallos)
 		api.DELETE("/clear-all", handler.ClearAllData)
 
 		// Settings routes

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -1171,6 +1172,109 @@ func (h *SubscriptionHandler) RestoreData(c *gin.Context) {
 		"message":        fmt.Sprintf("Successfully imported %d subscriptions", imported),
 		"imported_count": imported,
 		"total_in_file":  len(backup.Subscriptions),
+		"mode":           mode,
+	}
+	if len(errors) > 0 {
+		result["errors"] = errors
+		result["partial_success"] = true
+		c.JSON(http.StatusMultiStatus, result)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// ImportWallos imports subscriptions from a Wallos "Export to JSON" file,
+// complementing the CSV/JSON/iCal export and the backup restore paths.
+func (h *SubscriptionHandler) ImportWallos(c *gin.Context) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 10<<20) // 10 MB limit
+
+	file, _, err := c.Request.FormFile("wallos_file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No Wallos export file provided or file too large (max 10 MB)"})
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read uploaded file"})
+		return
+	}
+
+	subscriptions, warnings, err := service.NewWallosImportService().Parse(data)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if len(subscriptions) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":    "No importable subscriptions found in the Wallos export",
+			"warnings": warnings,
+		})
+		return
+	}
+
+	mode := c.PostForm("mode")
+	if mode == "" {
+		mode = "merge"
+	}
+	if mode != "replace" && mode != "merge" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid mode, must be 'replace' or 'merge'"})
+		return
+	}
+
+	if mode == "replace" {
+		existing, err := h.service.GetAll()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch existing data"})
+			return
+		}
+		for _, sub := range existing {
+			if err := h.service.Delete(sub.ID); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to clear existing data: %v", err)})
+				return
+			}
+		}
+	}
+
+	// Build a name->id map of existing categories, creating any that are missing.
+	categoryMap := make(map[string]uint)
+	categories, _ := h.categoryService.GetAll()
+	for _, cat := range categories {
+		categoryMap[cat.Name] = cat.ID
+	}
+
+	imported := 0
+	errors := append([]string{}, warnings...)
+	for _, sub := range subscriptions {
+		if sub.Category.Name != "" {
+			if catID, ok := categoryMap[sub.Category.Name]; ok {
+				sub.CategoryID = catID
+			} else {
+				newCat := &models.Category{Name: sub.Category.Name}
+				if created, err := h.categoryService.Create(newCat); err == nil {
+					categoryMap[created.Name] = created.ID
+					sub.CategoryID = created.ID
+				}
+			}
+		}
+
+		// Reset associations/identity so GORM performs a clean insert.
+		sub.ID = 0
+		sub.Category = models.Category{}
+
+		if _, err := h.service.Create(&sub); err != nil {
+			errors = append(errors, fmt.Sprintf("Failed to import '%s': %v", sub.Name, err))
+			continue
+		}
+		imported++
+	}
+
+	result := gin.H{
+		"message":        fmt.Sprintf("Successfully imported %d subscriptions from Wallos", imported),
+		"imported_count": imported,
+		"total_in_file":  len(subscriptions) + len(warnings),
 		"mode":           mode,
 	}
 	if len(errors) > 0 {

--- a/internal/handlers/wallos_import_test.go
+++ b/internal/handlers/wallos_import_test.go
@@ -1,0 +1,169 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"subtrackr/internal/database"
+	"subtrackr/internal/models"
+	"subtrackr/internal/repository"
+	"subtrackr/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const wallosFixture = `{
+  "success": true,
+  "subscriptions": [
+    {"Name":"Netflix","Payment Cycle":"Monthly","Next Payment":"2026-01-15","Category":"Entertainment","Payment Method":"Visa","Paid By":"Alice","Price":"$15.99","Notes":"Family","URL":"https://netflix.com","Notifications":"Enabled","Active":"Yes"},
+    {"Name":"Adobe","Payment Cycle":"Yearly","Next Payment":"2026-06-01","Category":"Productivity","Price":"€59,99","Cancellation Date":"2026-05-20","Notifications":"Disabled","Active":"No"},
+    {"Name":"","Payment Cycle":"Monthly","Price":"$1","Active":"Yes"}
+  ]
+}`
+
+// newWallosTestHandler wires the subscription + category services needed by
+// ImportWallos against an in-memory database.
+func newWallosTestHandler(t *testing.T) (*gin.Engine, *service.SubscriptionService, *service.CategoryService) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, database.RunMigrations(db))
+
+	categoryService := service.NewCategoryService(repository.NewCategoryRepository(db))
+	subscriptionService := service.NewSubscriptionService(repository.NewSubscriptionRepository(db), categoryService)
+	settingsService := service.NewSettingsService(repository.NewSettingsRepository(db))
+	currencyService := service.NewCurrencyService(repository.NewExchangeRateRepository(db))
+
+	handler := NewSubscriptionHandler(
+		subscriptionService,
+		settingsService,
+		currencyService,
+		nil, // emailService
+		nil, // pushoverService
+		nil, // webhookService
+		nil, // logoService
+		categoryService,
+		nil, // tagService
+		nil, // i18nCatalog
+	)
+
+	router := gin.New()
+	router.POST("/api/import/wallos", handler.ImportWallos)
+	return router, subscriptionService, categoryService
+}
+
+func postWallosFile(t *testing.T, router *gin.Engine, field, filename, content, mode string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	if mode != "" {
+		require.NoError(t, writer.WriteField("mode", mode))
+	}
+	part, err := writer.CreateFormFile(field, filename)
+	require.NoError(t, err)
+	_, err = part.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/import/wallos", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+// Integration/Functional — a full multipart upload imports the valid rows,
+// creates categories, and reports the skipped row.
+func TestImportWallos_Integration_HappyPath(t *testing.T) {
+	router, subService, catService := newWallosTestHandler(t)
+
+	rec := postWallosFile(t, router, "wallos_file", "wallos.json", wallosFixture, "merge")
+
+	// One row is skipped (empty name) -> 207 Multi-Status with a warning.
+	require.Equal(t, http.StatusMultiStatus, rec.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, float64(2), resp["imported_count"])
+
+	subs, err := subService.GetAll()
+	require.NoError(t, err)
+	require.Len(t, subs, 2)
+
+	names := map[string]bool{}
+	for _, s := range subs {
+		names[s.Name] = true
+	}
+	assert.True(t, names["Netflix"])
+	assert.True(t, names["Adobe"])
+
+	// Categories from the export were created.
+	cats, err := catService.GetAll()
+	require.NoError(t, err)
+	catNames := map[string]bool{}
+	for _, c := range cats {
+		catNames[c.Name] = true
+	}
+	assert.True(t, catNames["Entertainment"])
+	assert.True(t, catNames["Productivity"])
+}
+
+// Security/Frame — a missing file field is rejected with 400.
+func TestImportWallos_NoFile(t *testing.T) {
+	router, _, _ := newWallosTestHandler(t)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	require.NoError(t, writer.Close())
+	req := httptest.NewRequest(http.MethodPost, "/api/import/wallos", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// Security — a non-Wallos JSON upload is rejected rather than silently importing.
+func TestImportWallos_RejectsNonWallosJSON(t *testing.T) {
+	router, subService, _ := newWallosTestHandler(t)
+
+	rec := postWallosFile(t, router, "wallos_file", "bad.json", `{"foo":"bar"}`, "merge")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	subs, err := subService.GetAll()
+	require.NoError(t, err)
+	assert.Empty(t, subs)
+}
+
+// Functional — replace mode clears existing data first.
+func TestImportWallos_ReplaceMode(t *testing.T) {
+	router, subService, _ := newWallosTestHandler(t)
+
+	// Seed one existing subscription.
+	_, err := subService.Create(&models.Subscription{
+		Name:     "Existing",
+		Cost:     9.99,
+		Schedule: "Monthly",
+		Status:   "Active",
+	})
+	require.NoError(t, err)
+
+	valid := `{"success":true,"subscriptions":[{"Name":"OnlyOne","Payment Cycle":"Monthly","Price":"$5","Active":"Yes"}]}`
+	rec := postWallosFile(t, router, "wallos_file", "wallos.json", valid, "replace")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	subs, err := subService.GetAll()
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+	assert.Equal(t, "OnlyOne", subs[0].Name)
+}

--- a/internal/service/wallos_import.go
+++ b/internal/service/wallos_import.go
@@ -1,0 +1,292 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"subtrackr/internal/models"
+	"time"
+)
+
+// WallosImportService parses a Wallos "Export to JSON" file into SubTrackr
+// subscription models. It complements the existing CSV/JSON/iCal import paths.
+//
+// The Wallos export (endpoints/subscriptions/export.php) produces a top-level
+// object of the shape:
+//
+//	{
+//	  "success": true,
+//	  "subscriptions": [
+//	    {
+//	      "Name": "Netflix",
+//	      "Payment Cycle": "Monthly",          // or "Every 3 Months"
+//	      "Next Payment": "2026-01-15",
+//	      "Renewal": "Automatic",              // or "Manual"
+//	      "Category": "Entertainment",
+//	      "Payment Method": "Visa",
+//	      "Paid By": "Alice",
+//	      "Price": "$15.99",                    // currency symbol + amount
+//	      "Notes": "...",
+//	      "URL": "https://netflix.com",
+//	      "State": "Enabled",                   // or "Disabled"
+//	      "Notifications": "Enabled",           // or "Disabled"
+//	      "Cancellation Date": "",
+//	      "Active": "Yes"                        // or "No"
+//	    }
+//	  ]
+//	}
+type WallosImportService struct{}
+
+// NewWallosImportService creates a new Wallos import service.
+func NewWallosImportService() *WallosImportService {
+	return &WallosImportService{}
+}
+
+// wallosSubscription mirrors a single entry in the Wallos export. Every field is
+// a string in the Wallos export, including Price and Active.
+type wallosSubscription struct {
+	Name             string `json:"Name"`
+	PaymentCycle     string `json:"Payment Cycle"`
+	NextPayment      string `json:"Next Payment"`
+	Renewal          string `json:"Renewal"`
+	Category         string `json:"Category"`
+	PaymentMethod    string `json:"Payment Method"`
+	PaidBy           string `json:"Paid By"`
+	Price            string `json:"Price"`
+	Notes            string `json:"Notes"`
+	URL              string `json:"URL"`
+	State            string `json:"State"`
+	Notifications    string `json:"Notifications"`
+	CancellationDate string `json:"Cancellation Date"`
+	Active           string `json:"Active"`
+}
+
+// wallosExport is the top-level Wallos export envelope.
+type wallosExport struct {
+	Success       bool                 `json:"success"`
+	Subscriptions []wallosSubscription `json:"subscriptions"`
+}
+
+// everyCycleRe matches Wallos multi-period cycles like "Every 3 Months".
+var everyCycleRe = regexp.MustCompile(`(?i)^every\s+(\d+)\s+(day|week|month|year)s?$`)
+
+// symbolToCurrency maps distinctive currency symbols to their canonical ISO
+// code. Symbols that are genuinely shared across currencies (notably "¥" for
+// JPY/CNY and "kr" for the Scandinavian krona/krone) are intentionally left out
+// so we fall back to the instance default rather than guessing wrong. Currency
+// is a best-effort convenience only; SubTrackr defaults to the instance
+// currency when this is empty.
+var symbolToCurrency = map[string]string{
+	"$":    "USD",
+	"€":    "EUR",
+	"£":    "GBP",
+	"₹":    "INR",
+	"₽":    "RUB",
+	"₩":    "KRW",
+	"R$":   "BRL",
+	"A$":   "AUD",
+	"C$":   "CAD",
+	"NZ$":  "NZD",
+	"S$":   "SGD",
+	"HK$":  "HKD",
+	"NT$":  "TWD",
+	"Mex$": "MXN",
+	"zł":   "PLN",
+}
+
+// Parse reads a Wallos export and returns the mapped subscriptions along with
+// per-row warnings for entries that were skipped or could not be fully mapped.
+// A non-nil error is only returned when the file itself is not a valid Wallos
+// export (bad JSON or no subscriptions array).
+func (s *WallosImportService) Parse(data []byte) ([]models.Subscription, []string, error) {
+	var export wallosExport
+	if err := json.Unmarshal(data, &export); err != nil {
+		return nil, nil, fmt.Errorf("invalid Wallos export: not valid JSON: %w", err)
+	}
+
+	// Guard against arbitrary JSON that happens to parse but isn't a Wallos
+	// export. The "subscriptions" key is required.
+	if export.Subscriptions == nil {
+		return nil, nil, fmt.Errorf("invalid Wallos export: missing \"subscriptions\" array")
+	}
+
+	var subs []models.Subscription
+	var warnings []string
+
+	for i, w := range export.Subscriptions {
+		name := strings.TrimSpace(w.Name)
+		if name == "" {
+			warnings = append(warnings, fmt.Sprintf("entry %d skipped: missing name", i+1))
+			continue
+		}
+
+		cost, currency, err := parseWallosPrice(w.Price)
+		if err != nil || cost <= 0 {
+			warnings = append(warnings, fmt.Sprintf("%q skipped: unusable price %q", name, w.Price))
+			continue
+		}
+
+		schedule, interval := parseWallosCycle(w.PaymentCycle)
+
+		sub := models.Subscription{
+			Name:             name,
+			Cost:             cost,
+			Schedule:         schedule,
+			ScheduleInterval: interval,
+			Status:           wallosStatus(w),
+			OriginalCurrency: currency,
+			PaymentMethod:    strings.TrimSpace(w.PaymentMethod),
+			Account:          strings.TrimSpace(w.PaidBy),
+			URL:              strings.TrimSpace(w.URL),
+			Notes:            strings.TrimSpace(w.Notes),
+			RenewalDate:      parseWallosDate(w.NextPayment),
+			CancellationDate: parseWallosDate(w.CancellationDate),
+			ReminderEnabled:  !strings.EqualFold(strings.TrimSpace(w.Notifications), "Disabled"),
+		}
+
+		if cat := strings.TrimSpace(w.Category); cat != "" {
+			sub.Category = models.Category{Name: cat}
+		}
+
+		subs = append(subs, sub)
+	}
+
+	return subs, warnings, nil
+}
+
+// parseWallosPrice extracts the numeric amount and (best-effort) currency code
+// from a Wallos price string such as "$15.99", "€9,99" or "15.99".
+func parseWallosPrice(raw string) (float64, string, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 0, "", fmt.Errorf("empty price")
+	}
+
+	// Identify the leading currency symbol (everything before the first digit,
+	// sign, or decimal separator).
+	numStart := strings.IndexFunc(s, func(r rune) bool {
+		return (r >= '0' && r <= '9') || r == '-' || r == '.' || r == ','
+	})
+	currency := ""
+	if numStart > 0 {
+		symbol := strings.TrimSpace(s[:numStart])
+		if code, ok := symbolToCurrency[symbol]; ok {
+			currency = code
+		}
+	}
+
+	// Keep only the numeric portion.
+	numPart := s
+	if numStart >= 0 {
+		numPart = s[numStart:]
+	}
+	numPart = strings.Map(func(r rune) rune {
+		if (r >= '0' && r <= '9') || r == '-' || r == '.' || r == ',' {
+			return r
+		}
+		return -1
+	}, numPart)
+
+	// Normalise decimal separator: if both separators are present, assume the
+	// last one is the decimal point and the other is a thousands separator.
+	numPart = normaliseDecimal(numPart)
+	if numPart == "" {
+		return 0, "", fmt.Errorf("no numeric value in %q", raw)
+	}
+
+	val, err := strconv.ParseFloat(numPart, 64)
+	if err != nil {
+		return 0, "", fmt.Errorf("could not parse amount from %q: %w", raw, err)
+	}
+	return val, currency, nil
+}
+
+// normaliseDecimal converts a numeric string that may use "," as either a
+// thousands or decimal separator into a plain "." decimal form.
+func normaliseDecimal(s string) string {
+	lastDot := strings.LastIndex(s, ".")
+	lastComma := strings.LastIndex(s, ",")
+	switch {
+	case lastComma == -1:
+		return s // only dots (or none): already fine
+	case lastDot == -1:
+		// Only commas present: treat the last comma as the decimal separator,
+		// drop any earlier commas (thousands separators).
+		s = strings.ReplaceAll(s[:lastComma], ",", "") + "." + s[lastComma+1:]
+		return s
+	case lastComma > lastDot:
+		// "1.234,56" -> comma is decimal
+		return strings.ReplaceAll(s[:lastComma], ".", "") + "." + s[lastComma+1:]
+	default:
+		// "1,234.56" -> dot is decimal
+		return strings.ReplaceAll(s[:lastDot], ",", "") + "." + s[lastDot+1:]
+	}
+}
+
+// parseWallosCycle maps a Wallos "Payment Cycle" string to a SubTrackr schedule
+// and interval. Recognised singular cycles: Daily/Weekly/Monthly/Yearly.
+// Multi-period cycles ("Every N Days/Weeks/Months/Years") map to the same base
+// schedule with the interval set to N. Unknown values default to Monthly/1.
+func parseWallosCycle(raw string) (schedule string, interval int) {
+	s := strings.TrimSpace(raw)
+
+	unitToSchedule := map[string]string{
+		"day":   "Daily",
+		"week":  "Weekly",
+		"month": "Monthly",
+		"year":  "Annual",
+	}
+
+	if m := everyCycleRe.FindStringSubmatch(s); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		if n < 1 {
+			n = 1
+		}
+		if sched, ok := unitToSchedule[strings.ToLower(m[2])]; ok {
+			return sched, n
+		}
+	}
+
+	switch strings.ToLower(s) {
+	case "daily":
+		return "Daily", 1
+	case "weekly":
+		return "Weekly", 1
+	case "monthly":
+		return "Monthly", 1
+	case "yearly", "annual", "annually":
+		return "Annual", 1
+	default:
+		return "Monthly", 1
+	}
+}
+
+// parseWallosDate parses a Wallos date field, tolerating the common formats and
+// empty values (returning nil for empty/unparseable input).
+func parseWallosDate(raw string) *time.Time {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil
+	}
+	formats := []string{"2006-01-02", "2006-01-02 15:04:05", time.RFC3339, "02/01/2006", "01/02/2006"}
+	for _, f := range formats {
+		if t, err := time.Parse(f, s); err == nil {
+			return &t
+		}
+	}
+	return nil
+}
+
+// wallosStatus maps the Wallos active/cancellation fields to a SubTrackr status.
+func wallosStatus(w wallosSubscription) string {
+	active := strings.EqualFold(strings.TrimSpace(w.Active), "Yes")
+	if active {
+		return "Active"
+	}
+	if strings.TrimSpace(w.CancellationDate) != "" {
+		return "Cancelled"
+	}
+	return "Paused"
+}

--- a/internal/service/wallos_import_test.go
+++ b/internal/service/wallos_import_test.go
@@ -1,0 +1,313 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sampleWallosExport is a representative Wallos "Export to JSON" payload.
+const sampleWallosExport = `{
+  "success": true,
+  "subscriptions": [
+    {
+      "Name": "Netflix",
+      "Payment Cycle": "Monthly",
+      "Next Payment": "2026-01-15",
+      "Renewal": "Automatic",
+      "Category": "Entertainment",
+      "Payment Method": "Visa",
+      "Paid By": "Alice",
+      "Price": "$15.99",
+      "Notes": "Family plan",
+      "URL": "https://netflix.com",
+      "State": "Enabled",
+      "Notifications": "Enabled",
+      "Cancellation Date": "",
+      "Active": "Yes"
+    },
+    {
+      "Name": "Adobe CC",
+      "Payment Cycle": "Yearly",
+      "Next Payment": "2026-06-01",
+      "Renewal": "Manual",
+      "Category": "Productivity",
+      "Payment Method": "PayPal",
+      "Paid By": "Bob",
+      "Price": "€59,99",
+      "Notes": "",
+      "URL": "https://adobe.com",
+      "State": "Disabled",
+      "Notifications": "Disabled",
+      "Cancellation Date": "2026-05-20",
+      "Active": "No"
+    },
+    {
+      "Name": "Storage Box",
+      "Payment Cycle": "Every 3 Months",
+      "Next Payment": "2026-02-10",
+      "Renewal": "Automatic",
+      "Category": "Storage",
+      "Payment Method": "SEPA",
+      "Paid By": "Alice",
+      "Price": "£8.50",
+      "Notes": "Hetzner",
+      "URL": "",
+      "State": "Enabled",
+      "Notifications": "Enabled",
+      "Cancellation Date": "",
+      "Active": "Yes"
+    }
+  ]
+}`
+
+// -----------------------------------------------------------------------------
+// Functional — full parse of a realistic export maps every field correctly
+// -----------------------------------------------------------------------------
+
+func TestWallosImport_Parse_Functional(t *testing.T) {
+	svc := NewWallosImportService()
+	subs, warnings, err := svc.Parse([]byte(sampleWallosExport))
+	require.NoError(t, err)
+	assert.Empty(t, warnings, "well-formed export should produce no warnings")
+	require.Len(t, subs, 3)
+
+	// Netflix: monthly, active, USD, has category + renewal date.
+	nf := subs[0]
+	assert.Equal(t, "Netflix", nf.Name)
+	assert.InDelta(t, 15.99, nf.Cost, 0.001)
+	assert.Equal(t, "Monthly", nf.Schedule)
+	assert.Equal(t, 1, nf.ScheduleInterval)
+	assert.Equal(t, "Active", nf.Status)
+	assert.Equal(t, "USD", nf.OriginalCurrency)
+	assert.Equal(t, "Visa", nf.PaymentMethod)
+	assert.Equal(t, "Alice", nf.Account)
+	assert.Equal(t, "Entertainment", nf.Category.Name)
+	assert.Equal(t, "Family plan", nf.Notes)
+	assert.True(t, nf.ReminderEnabled)
+	require.NotNil(t, nf.RenewalDate)
+	assert.Equal(t, "2026-01-15", nf.RenewalDate.Format("2006-01-02"))
+	assert.Nil(t, nf.CancellationDate)
+
+	// Adobe: yearly -> Annual, cancelled (Active No + cancellation date), EUR,
+	// European decimal comma, notifications disabled.
+	ad := subs[1]
+	assert.Equal(t, "Adobe CC", ad.Name)
+	assert.InDelta(t, 59.99, ad.Cost, 0.001)
+	assert.Equal(t, "Annual", ad.Schedule)
+	assert.Equal(t, "Cancelled", ad.Status)
+	assert.Equal(t, "EUR", ad.OriginalCurrency)
+	assert.False(t, ad.ReminderEnabled)
+	require.NotNil(t, ad.CancellationDate)
+	assert.Equal(t, "2026-05-20", ad.CancellationDate.Format("2006-01-02"))
+
+	// Storage: "Every 3 Months" -> Monthly interval 3, GBP.
+	sb := subs[2]
+	assert.Equal(t, "Monthly", sb.Schedule)
+	assert.Equal(t, 3, sb.ScheduleInterval)
+	assert.Equal(t, "GBP", sb.OriginalCurrency)
+	assert.InDelta(t, 8.50, sb.Cost, 0.001)
+}
+
+// -----------------------------------------------------------------------------
+// Unit — individual field mapping helpers
+// -----------------------------------------------------------------------------
+
+func TestWallosImport_ParseCycle_Unit(t *testing.T) {
+	cases := []struct {
+		in       string
+		schedule string
+		interval int
+	}{
+		{"Daily", "Daily", 1},
+		{"Weekly", "Weekly", 1},
+		{"Monthly", "Monthly", 1},
+		{"Yearly", "Annual", 1},
+		{"Every 2 Weeks", "Weekly", 2},
+		{"Every 3 Months", "Monthly", 3},
+		{"Every 5 Years", "Annual", 5},
+		{"every 4 days", "Daily", 4}, // case-insensitive
+		{"Bogus", "Monthly", 1},      // unknown -> default
+		{"", "Monthly", 1},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			s, i := parseWallosCycle(c.in)
+			assert.Equal(t, c.schedule, s)
+			assert.Equal(t, c.interval, i)
+		})
+	}
+}
+
+func TestWallosImport_ParsePrice_Unit(t *testing.T) {
+	cases := []struct {
+		in       string
+		amount   float64
+		currency string
+		wantErr  bool
+	}{
+		{"$15.99", 15.99, "USD", false},
+		{"€9,99", 9.99, "EUR", false},
+		{"£8.50", 8.50, "GBP", false},
+		{"15.99", 15.99, "", false},       // no symbol -> default currency
+		{"$1,234.56", 1234.56, "USD", false},
+		{"1.234,56 €", 1234.56, "", false}, // trailing symbol not detected -> empty currency, amount still parsed
+		{"", 0, "", true},
+		{"abc", 0, "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			amt, cur, err := parseWallosPrice(c.in)
+			if c.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.InDelta(t, c.amount, amt, 0.001)
+			assert.Equal(t, c.currency, cur)
+		})
+	}
+}
+
+func TestWallosImport_Status_Unit(t *testing.T) {
+	assert.Equal(t, "Active", wallosStatus(wallosSubscription{Active: "Yes"}))
+	assert.Equal(t, "Cancelled", wallosStatus(wallosSubscription{Active: "No", CancellationDate: "2026-01-01"}))
+	assert.Equal(t, "Paused", wallosStatus(wallosSubscription{Active: "No"}))
+}
+
+func TestWallosImport_ParseDate_Unit(t *testing.T) {
+	assert.Nil(t, parseWallosDate(""))
+	assert.Nil(t, parseWallosDate("not-a-date"))
+	d := parseWallosDate("2026-03-04")
+	require.NotNil(t, d)
+	assert.Equal(t, "2026-03-04", d.Format("2006-01-02"))
+}
+
+// -----------------------------------------------------------------------------
+// Frame — boundary conditions and skipping rules
+// -----------------------------------------------------------------------------
+
+func TestWallosImport_Frame_SkipsAndBoundaries(t *testing.T) {
+	svc := NewWallosImportService()
+
+	payload := `{"success":true,"subscriptions":[
+	  {"Name":"","Price":"$5","Payment Cycle":"Monthly","Active":"Yes"},
+	  {"Name":"NoPrice","Price":"","Payment Cycle":"Monthly","Active":"Yes"},
+	  {"Name":"ZeroPrice","Price":"$0","Payment Cycle":"Monthly","Active":"Yes"},
+	  {"Name":"Good","Price":"$1","Payment Cycle":"Monthly","Active":"Yes"}
+	]}`
+	subs, warnings, err := svc.Parse([]byte(payload))
+	require.NoError(t, err)
+	require.Len(t, subs, 1, "only the valid row should be imported")
+	assert.Equal(t, "Good", subs[0].Name)
+	assert.Len(t, warnings, 3, "missing name, empty price, and zero price should each warn")
+
+	// Empty subscriptions array is valid but yields nothing.
+	subs, warnings, err = svc.Parse([]byte(`{"success":true,"subscriptions":[]}`))
+	require.NoError(t, err)
+	assert.Empty(t, subs)
+	assert.Empty(t, warnings)
+}
+
+// -----------------------------------------------------------------------------
+// Security — adversarial / malformed input is rejected without panicking
+// -----------------------------------------------------------------------------
+
+func TestWallosImport_Security_RejectsBadInput(t *testing.T) {
+	svc := NewWallosImportService()
+
+	// Not JSON at all.
+	_, _, err := svc.Parse([]byte("not json"))
+	assert.Error(t, err)
+
+	// Valid JSON but not a Wallos export (no subscriptions key). Must be
+	// rejected so arbitrary uploads can't be silently imported.
+	_, _, err = svc.Parse([]byte(`{"foo":"bar"}`))
+	assert.Error(t, err)
+
+	// Wrong types where strings are expected must not panic.
+	assert.NotPanics(t, func() {
+		_, _, _ = svc.Parse([]byte(`{"subscriptions":[{"Name":123}]}`))
+	})
+
+	// Deeply nested / hostile JSON must not panic.
+	assert.NotPanics(t, func() {
+		_, _, _ = svc.Parse([]byte(`{"subscriptions":[{"Name":"x","Price":{"nested":true}}]}`))
+	})
+}
+
+// -----------------------------------------------------------------------------
+// Performance — parsing a large export stays fast
+// -----------------------------------------------------------------------------
+
+func TestWallosImport_Performance_LargeExport(t *testing.T) {
+	const n = 5000
+	entries := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		entries = append(entries, fmt.Sprintf(
+			`{"Name":"Sub %d","Price":"$%d.99","Payment Cycle":"Monthly","Next Payment":"2026-01-15","Category":"Cat %d","Active":"Yes","Notifications":"Enabled"}`,
+			i, i%50+1, i%10))
+	}
+	payload := `{"success":true,"subscriptions":[` + strings.Join(entries, ",") + `]}`
+
+	svc := NewWallosImportService()
+	start := time.Now()
+	subs, warnings, err := svc.Parse([]byte(payload))
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Len(t, subs, n)
+	assert.Less(t, elapsed, 2*time.Second, "parsing %d entries should be fast", n)
+}
+
+// -----------------------------------------------------------------------------
+// Retry — not applicable
+// -----------------------------------------------------------------------------
+
+// The Wallos importer is a purely local, deterministic transformation of an
+// uploaded file into subscription models. It performs no network or other
+// external I/O, so there is nothing to retry with backoff. This placeholder
+// documents that the Retry category was considered and is intentionally N/A.
+func TestWallosImport_Retry_NotApplicable(t *testing.T) {
+	t.Skip("N/A: import parsing has no external calls, so retry/backoff does not apply")
+}
+
+// -----------------------------------------------------------------------------
+// Integration — parse a realistic multi-entry export and confirm the aggregate
+// mapping (currencies, schedules, statuses, categories) end to end.
+// -----------------------------------------------------------------------------
+
+func TestWallosImport_Integration_AggregateMapping(t *testing.T) {
+	svc := NewWallosImportService()
+	subs, warnings, err := svc.Parse([]byte(sampleWallosExport))
+	require.NoError(t, err)
+	require.Empty(t, warnings)
+
+	// Round-trip through JSON to ensure the produced models serialise cleanly
+	// (as they would when handed to the create path / API).
+	raw, err := json.Marshal(subs)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "Netflix")
+
+	schedules := map[string]int{}
+	statuses := map[string]int{}
+	categories := map[string]bool{}
+	for _, s := range subs {
+		schedules[s.Schedule]++
+		statuses[s.Status]++
+		if s.Category.Name != "" {
+			categories[s.Category.Name] = true
+		}
+	}
+	assert.Equal(t, 2, schedules["Monthly"]) // Netflix + Storage(every 3 months)
+	assert.Equal(t, 1, schedules["Annual"])  // Adobe
+	assert.Equal(t, 2, statuses["Active"])
+	assert.Equal(t, 1, statuses["Cancelled"])
+	assert.Len(t, categories, 3)
+}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -460,6 +460,29 @@
                         <div id="restore-message" class="mt-2 text-sm"></div>
                     </div>
 
+                    <div class="p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+                        <div class="flex items-center justify-between mb-3">
+                            <div>
+                                <h4 class="text-sm font-medium text-blue-900 dark:text-blue-200">{{t .Lang "settings.import_wallos"}}</h4>
+                                <p class="text-sm text-blue-800 dark:text-blue-300">{{t .Lang "settings.import_wallos_help"}}</p>
+                            </div>
+                        </div>
+                        <form id="wallos-form" enctype="multipart/form-data" onsubmit="submitWallosImport(event)">
+                            <div class="flex items-center gap-3">
+                                <input type="file" name="wallos_file" id="wallos_file" accept=".json" required
+                                    class="text-sm text-gray-700 dark:text-gray-300 file:mr-3 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-blue-100 file:text-blue-700 dark:file:bg-blue-800 dark:file:text-blue-200 hover:file:bg-blue-200 dark:hover:file:bg-blue-700">
+                                <select name="mode" class="text-sm border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white rounded-lg px-3 py-2">
+                                    <option value="merge">{{t .Lang "settings.restore_merge"}}</option>
+                                    <option value="replace">{{t .Lang "settings.restore_replace"}}</option>
+                                </select>
+                                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 whitespace-nowrap">
+                                    {{t .Lang "settings.import"}}
+                                </button>
+                            </div>
+                        </form>
+                        <div id="wallos-message" class="mt-2 text-sm"></div>
+                    </div>
+
                     <div class="flex items-center justify-between p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
                         <div>
                             <h4 class="text-sm font-medium text-red-800 dark:text-red-200">{{t .Lang "settings.clear_all"}}</h4>
@@ -1373,6 +1396,48 @@
             })
             .catch(() => {
                 msgDiv.textContent = 'Failed to restore backup';
+                msgDiv.className = 'mt-2 text-sm text-red-600 dark:text-red-400';
+            });
+        }
+
+        function submitWallosImport(event) {
+            event.preventDefault();
+            const form = document.getElementById('wallos-form');
+            const formData = new FormData(form);
+            const msgDiv = document.getElementById('wallos-message');
+            const mode = formData.get('mode');
+
+            if (mode === 'replace') {
+                if (!confirm('This will replace all existing subscription data with the Wallos import. Continue?')) {
+                    return;
+                }
+            }
+
+            msgDiv.textContent = 'Importing from Wallos...';
+            msgDiv.className = 'mt-2 text-sm text-blue-600 dark:text-blue-400';
+
+            fetch('/api/import/wallos', {
+                method: 'POST',
+                body: formData,
+            })
+            .then(r => r.json().then(data => ({status: r.status, ok: r.ok, data})))
+            .then(({status, ok, data}) => {
+                if (status === 207) {
+                    const failed = (data.errors && data.errors.length) || 0;
+                    msgDiv.textContent = data.message + ` (${failed} skipped/failed)`;
+                    msgDiv.className = 'mt-2 text-sm text-yellow-600 dark:text-yellow-400';
+                    setTimeout(() => location.reload(), 2000);
+                } else if (ok) {
+                    msgDiv.textContent = data.message;
+                    msgDiv.className = 'mt-2 text-sm text-green-600 dark:text-green-400';
+                    setTimeout(() => location.reload(), 1500);
+                } else {
+                    msgDiv.textContent = data.error;
+                    msgDiv.className = 'mt-2 text-sm text-red-600 dark:text-red-400';
+                }
+            })
+            .catch(() => {
+                msgDiv.textContent = 'Failed to import from Wallos';
                 msgDiv.className = 'mt-2 text-sm text-red-600 dark:text-red-400';
             });
         }

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -295,5 +295,9 @@
   "theme.dark_classic_desc": "Klassischer Dunkelmodus",
   "theme.christmas_desc": "Festlich und fröhlich!",
   "theme.midnight_desc": "Tief und geheimnisvoll",
-  "theme.ocean_desc": "Kühl und erfrischend"
+  "theme.ocean_desc": "Kühl und erfrischend",
+
+  "settings.import_wallos": "Aus Wallos importieren",
+  "settings.import_wallos_help": "Importieren Sie Ihre Abonnements aus einer Wallos-\"Export to JSON\"-Datei. Neue Kategorien werden automatisch erstellt.",
+  "settings.import": "Importieren"
 }

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -295,5 +295,9 @@
   "theme.dark_classic_desc": "Original dark mode",
   "theme.christmas_desc": "Festive and jolly!",
   "theme.midnight_desc": "Deep and mysterious",
-  "theme.ocean_desc": "Cool and refreshing"
+  "theme.ocean_desc": "Cool and refreshing",
+
+  "settings.import_wallos": "Import from Wallos",
+  "settings.import_wallos_help": "Import your subscriptions from a Wallos \"Export to JSON\" file. New categories are created automatically.",
+  "settings.import": "Import"
 }

--- a/web/locales/es.json
+++ b/web/locales/es.json
@@ -295,5 +295,9 @@
   "theme.dark_classic_desc": "Modo oscuro original",
   "theme.christmas_desc": "¡Festivo y alegre!",
   "theme.midnight_desc": "Profundo y misterioso",
-  "theme.ocean_desc": "Fresco y refrescante"
+  "theme.ocean_desc": "Fresco y refrescante",
+
+  "settings.import_wallos": "Importar desde Wallos",
+  "settings.import_wallos_help": "Importa tus suscripciones desde un archivo \"Export to JSON\" de Wallos. Las nuevas categorías se crean automáticamente.",
+  "settings.import": "Importar"
 }

--- a/web/locales/nl.json
+++ b/web/locales/nl.json
@@ -295,5 +295,9 @@
   "theme.dark_classic_desc": "Originele donkere modus",
   "theme.christmas_desc": "Feestelijk en vrolijk!",
   "theme.midnight_desc": "Diep en mysterieus",
-  "theme.ocean_desc": "Koel en verfrissend"
+  "theme.ocean_desc": "Koel en verfrissend",
+
+  "settings.import_wallos": "Importeren uit Wallos",
+  "settings.import_wallos_help": "Importeer je abonnementen uit een Wallos \"Export to JSON\"-bestand. Nieuwe categorieën worden automatisch aangemaakt.",
+  "settings.import": "Importeren"
 }


### PR DESCRIPTION
## Summary

Adds the ability to **import subscriptions from a Wallos "Export to JSON" file**, complementing the existing CSV / JSON / iCal export and the backup-restore paths. Requested in #65.

The mapping was derived from the upstream Wallos exporter (`endpoints/subscriptions/export.php`), which emits:

```json
{ "success": true, "subscriptions": [
  { "Name": "Netflix", "Payment Cycle": "Monthly", "Next Payment": "2026-01-15",
    "Renewal": "Automatic", "Category": "Entertainment", "Payment Method": "Visa",
    "Paid By": "Alice", "Price": "$15.99", "Notes": "", "URL": "...",
    "State": "Enabled", "Notifications": "Enabled", "Cancellation Date": "", "Active": "Yes" } ] }
```

## What's included

- **`internal/service/wallos_import.go`** — `WallosImportService.Parse` maps a Wallos export into `models.Subscription`:
  - `Payment Cycle` → `Schedule` + `ScheduleInterval` (`Daily`/`Weekly`/`Monthly`/`Yearly` and `Every N Days/Weeks/Months/Years`).
  - `Price` (`"$15.99"`, `"€59,99"`, `"£8.50"`, `"1.234,56"`) → `Cost`, plus best-effort ISO currency from the symbol; handles both US (`1,234.56`) and European (`1.234,56`) decimal styles. Ambiguous symbols (`¥`, `kr`) fall back to the instance default rather than guessing.
  - `Active` / `Cancellation Date` → `Status` (`Active` / `Cancelled` / `Paused`).
  - `Category` (auto-created), `Next Payment` → `RenewalDate`, `Paid By` → `Account`, plus `PaymentMethod`, `Notes`, `URL`, `Notifications` → `ReminderEnabled`.
  - Rows with no name or an unusable price are **skipped and returned as warnings**; JSON that isn't a Wallos export (missing `subscriptions`) is rejected so arbitrary uploads can't be silently imported.
- **`internal/handlers` `ImportWallos`** — multipart upload (`wallos_file`), 10 MB cap, `merge`/`replace` modes, mirroring the existing `RestoreData` flow; new route `POST /api/import/wallos`.
- **Settings UI** — an "Import from Wallos" card in the Data Management section with i18n keys for `en/de/es/nl`.

## Tests — all 7 categories

`internal/service/wallos_import_test.go`:
- **Unit** — cycle / price / date / status mapping (table-driven).
- **Functional** — full realistic export mapped field-by-field.
- **Frame** — skip rules (empty name, empty/zero price) and empty-array boundary.
- **Security** — non-JSON, non-Wallos JSON, and hostile/wrong-type JSON rejected without panicking.
- **Performance** — parses 5,000 entries well under budget.
- **Retry** — documented N/A (purely local transform, no external I/O).
- **Integration** — aggregate mapping across currencies/schedules/statuses/categories.

`internal/handlers/wallos_import_test.go` adds end-to-end multipart-upload tests against an in-memory DB (happy path with 207 + skipped-row reporting, missing file → 400, non-Wallos rejection, and replace-mode clearing).

## Verification

`go build ./... && go vet ./... && go test ./...` all pass; all templates parse with the server funcmap. Playwright e2e requires Node and defers to maintainer CI.

## Notes / scope

Targets the standard Wallos "Export to JSON" (human-readable) format. It does not attempt to import Wallos household members, custom currencies, or logos beyond the fields above — those can be follow-ups if desired.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)