### PR TITLE
Add currency support for UAH

### DIFF
--- a/internal/service/currency.go
+++ b/internal/service/currency.go
@@ -58,6 +58,7 @@ var BuiltinCurrencies = []CurrencyInfo{
 	{Code: "CZK", Symbol: "Kč", Name: "Czech Koruna"},
 	{Code: "HUF", Symbol: "Ft", Name: "Hungarian Forint"},
 	{Code: "RON", Symbol: "lei", Name: "Romanian Leu"},
+	{Code: "UAH", Symbol: "₴", Name: "Ukrainian Hryvnia"},
 }
 
 // currencyInfoMap provides O(1) lookup by code

--- a/internal/service/currency_test.go
+++ b/internal/service/currency_test.go
@@ -60,7 +60,7 @@ func TestGetAvailableCurrencies(t *testing.T) {
 
 	// Verify first and last entries match
 	assert.Equal(t, "USD", currencies[0].Code)
-	assert.Equal(t, "RON", currencies[len(currencies)-1].Code)
+	assert.Equal(t, "UAH", currencies[len(currencies)-1].Code)
 }
 
 func TestSupportedCurrencies_DerivedFromBuiltin(t *testing.T) {


### PR DESCRIPTION
It is already in the list of [supported currencies](https://fixer.io/symbols) at Fixer.io

Tested locally with Go 1.26.5: `go test ./... passes`, including internal/service currency coverage.