### PR TITLE
Fix adding USD subscriptions when USD is not the default currency

### DIFF
--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -965,6 +965,13 @@ func (h *SubscriptionHandler) GetStats(c *gin.Context) {
 	c.JSON(http.StatusOK, stats)
 }
 
+func subscriptionFormCurrency(subscription *models.Subscription, preferredCurrency string) string {
+	if subscription != nil && subscription.OriginalCurrency != "" {
+		return subscription.OriginalCurrency
+	}
+	return preferredCurrency
+}
+
 // GetSubscriptionForm returns the subscription form (for add/edit)
 func (h *SubscriptionHandler) GetSubscriptionForm(c *gin.Context) {
 	var subscription *models.Subscription
@@ -996,11 +1003,13 @@ func (h *SubscriptionHandler) GetSubscriptionForm(c *gin.Context) {
 		}
 		tagsCSV = strings.Join(names, ", ")
 	}
+	formCurrency := subscriptionFormCurrency(subscription, h.settingsService.GetCurrency())
 
 	c.HTML(http.StatusOK, "subscription-form.html", gin.H{
 		"Subscription":   subscription,
 		"IsEdit":         isEdit,
-		"CurrencySymbol": h.settingsService.GetCurrencySymbol(),
+		"CurrencySymbol": service.CurrencySymbolForCode(formCurrency),
+		"FormCurrency":   formCurrency,
 		"Categories":     categories,
 		"Currencies":     service.GetAvailableCurrencies(),
 		"TagsCSV":        tagsCSV,

--- a/internal/handlers/subscription_form_test.go
+++ b/internal/handlers/subscription_form_test.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"subtrackr/internal/database"
+	"subtrackr/internal/repository"
+	"subtrackr/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetSubscriptionForm_Integration_UsesPreferredCurrency(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, database.RunMigrations(db))
+
+	settingsService := service.NewSettingsService(repository.NewSettingsRepository(db))
+	require.NoError(t, settingsService.SetCurrency("SEK"))
+
+	categoryService := service.NewCategoryService(repository.NewCategoryRepository(db))
+	subscriptionService := service.NewSubscriptionService(repository.NewSubscriptionRepository(db), categoryService)
+	handler := NewSubscriptionHandler(
+		subscriptionService,
+		settingsService,
+		service.NewCurrencyService(repository.NewExchangeRateRepository(db)),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		categoryService,
+		nil,
+		nil,
+	)
+
+	formTemplate := template.Must(template.New("subscription-form.html").Funcs(template.FuncMap{
+		"t": func(_ interface{}, key string) string { return key },
+	}).ParseFiles("../../templates/subscription-form.html"))
+	router := gin.New()
+	router.SetHTMLTemplate(formTemplate)
+	router.GET("/form/subscription", handler.GetSubscriptionForm)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/form/subscription", nil)
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code, "body: %s", recorder.Body.String())
+	assert.Contains(t, recorder.Body.String(), `<option value="SEK" data-symbol="kr" selected>kr SEK</option>`)
+	assert.NotContains(t, recorder.Body.String(), `<option value="USD" data-symbol="$" selected>$ USD</option>`)
+}

--- a/internal/handlers/subscription_test.go
+++ b/internal/handlers/subscription_test.go
@@ -4,8 +4,43 @@ import (
 	"testing"
 	"time"
 
+	"subtrackr/internal/models"
+
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSubscriptionFormCurrency(t *testing.T) {
+	tests := []struct {
+		name              string
+		subscription      *models.Subscription
+		preferredCurrency string
+		expected          string
+	}{
+		{
+			name:              "new subscription uses preferred currency",
+			preferredCurrency: "SEK",
+			expected:          "SEK",
+		},
+		{
+			name:              "existing subscription uses original currency",
+			subscription:      &models.Subscription{OriginalCurrency: "USD"},
+			preferredCurrency: "SEK",
+			expected:          "USD",
+		},
+		{
+			name:              "existing subscription without currency uses preferred currency",
+			subscription:      &models.Subscription{},
+			preferredCurrency: "SEK",
+			expected:          "SEK",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, subscriptionFormCurrency(tt.subscription, tt.preferredCurrency))
+		})
+	}
+}
 
 func TestParseDatePtr(t *testing.T) {
 	tests := []struct {
@@ -105,4 +140,3 @@ func TestParseDatePtr(t *testing.T) {
 func timePtr(t time.Time) *time.Time {
 	return &t
 }
-

--- a/templates/subscription-form.html
+++ b/templates/subscription-form.html
@@ -92,7 +92,7 @@
             <div>
                 <label for="cost" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{t .Lang "form.cost"}} *</label>
                 <div class="relative">
-                    <span class="absolute left-3 top-2 text-gray-500 dark:text-gray-400">{{.CurrencySymbol}}</span>
+                    <span id="cost-currency-symbol" class="absolute left-3 top-2 text-gray-500 dark:text-gray-400">{{.CurrencySymbol}}</span>
                     <input type="number" id="cost" name="cost" step="0.01" min="0" required
                            value="{{if .Subscription}}{{.Subscription.Cost}}{{end}}"
                            class="w-full pl-8 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition-colors duration-150">
@@ -114,10 +114,10 @@
             <!-- Original Currency -->
             <div>
                 <label for="original_currency" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{t .Lang "form.currency"}} *</label>
-                <select id="original_currency" name="original_currency" required
+                <select id="original_currency" name="original_currency" required onchange="updateCostCurrencySymbol()"
                         class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition-colors duration-150">
                     {{range .Currencies}}
-                    <option value="{{.Code}}" {{if $.Subscription}}{{if eq $.Subscription.OriginalCurrency .Code}}selected{{end}}{{else}}{{if eq .Code "USD"}}selected{{end}}{{end}}>{{.Symbol}} {{.Code}}</option>
+                    <option value="{{.Code}}" data-symbol="{{.Symbol}}" {{if eq $.FormCurrency .Code}}selected{{end}}>{{.Symbol}} {{.Code}}</option>
                     {{end}}
                 </select>
             </div>
@@ -370,6 +370,12 @@ function updateScheduleFields() {
     scheduleInput.value = parts[0];
     intervalInput.value = parts[1] || '1';
     calculateRenewalDate();
+}
+
+function updateCostCurrencySymbol() {
+    const currencySelect = document.getElementById('original_currency');
+    const currencySymbol = document.getElementById('cost-currency-symbol');
+    currencySymbol.textContent = currencySelect.selectedOptions[0].dataset.symbol;
 }
 
 function initScheduleCombo() {

--- a/tests/subscription-currency.spec.js
+++ b/tests/subscription-currency.spec.js
@@ -1,0 +1,50 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test('updates the cost prefix and submits the selected currency', async ({ page }) => {
+  let categories = await (await page.request.get('/api/categories')).json();
+  if (categories.length === 0) {
+    const categoryResponse = await page.request.post('/api/categories', {
+      data: { name: `Currency Test ${Date.now()}` },
+    });
+    categories = [await categoryResponse.json()];
+  }
+
+  await page.goto('/subscriptions');
+  await page.locator('header button:has-text("Add"), header button:has-text("Añadir")').first().click();
+  await page.waitForSelector('input[name="name"]');
+
+  const currency = page.locator('select[name="original_currency"]');
+  const costPrefix = page.locator('#cost-currency-symbol');
+
+  await currency.selectOption('SEK');
+  await expect(costPrefix).toHaveText('kr');
+
+  await currency.selectOption('USD');
+  await expect(costPrefix).toHaveText('$');
+
+  const subscriptionName = `USD Currency Test ${Date.now()}`;
+  await page.fill('input[name="name"]', subscriptionName);
+  await page.fill('input[name="cost"]', '9.99');
+  await page.selectOption('select[name="category_id"]', String(categories[0].id));
+  await page.selectOption('select#schedule_combo', 'Monthly_1');
+  await page.selectOption('select[name="status"]', 'Active');
+
+  const createResponse = page.waitForResponse(response =>
+    response.url().endsWith('/api/subscriptions') && response.request().method() === 'POST'
+  );
+  await page.locator('form button[type="submit"]').click();
+  await createResponse;
+  await page.waitForLoadState('networkidle');
+
+  const row = page.locator('tr', { hasText: subscriptionName }).first();
+  await expect(row).toBeVisible();
+  const editButton = row.locator('button[title*="Edit"], button[title*="Editar"], button[title*="Bearbeiten"], button[title*="Bewerken"]');
+  const editPath = await editButton.getAttribute('hx-get');
+  if (!editPath) throw new Error('Edit button is missing its subscription path');
+  await editButton.click();
+  await expect(page.locator('select[name="original_currency"]')).toHaveValue('USD');
+
+  const subscriptionID = editPath.split('/').pop();
+  await page.request.delete(`/api/subscriptions/${subscriptionID}`);
+});


### PR DESCRIPTION
Hey,

I experienced this issue when trying to add subscriptions which are predominantly in SEK. But I have a few in USD.

When opening the add new subscription modal the dropdown for currency was still showing USD and the prefix for the cost input was however "kr" (the symbol for SEK). Selecting a different currency in the dropdown did not change the prefix.

Furthermore when leaving it as USD it would still add the subscription as the default currency.

This PR fixes the issue. 