### PR TITLE
Better multi-currency support

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -30,9 +30,13 @@ func main() {
 	}
 
 	subscriptionRepo := repository.NewSubscriptionRepository(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	exchangeRateRepo := repository.NewExchangeRateRepository(db)
 	categoryRepo := repository.NewCategoryRepository(db)
 	categoryService := service.NewCategoryService(categoryRepo)
 	subscriptionService := service.NewSubscriptionService(subscriptionRepo, categoryService)
+	settingsService := service.NewSettingsService(settingsRepo)
+	currencyService := service.NewCurrencyService(exchangeRateRepo, settingsRepo)
 
 	server := mcp.NewServer(
 		&mcp.Implementation{Name: "subtrackr", Version: version.GetVersion()},
@@ -226,7 +230,7 @@ func main() {
 		Name:        "get_stats",
 		Description: "Get subscription statistics including total spending, counts, and category breakdown",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input StatsInput) (*mcp.CallToolResult, *models.Stats, error) {
-		stats, err := subscriptionService.GetStats()
+		stats, err := subscriptionService.GetStats(currencyService, settingsService.GetCurrency())
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get stats: %w", err)
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	// Initialize services
 	categoryService := service.NewCategoryService(categoryRepo)
-	currencyService := service.NewCurrencyService(exchangeRateRepo)
+	currencyService := service.NewCurrencyService(exchangeRateRepo, settingsRepo)
 	subscriptionService := service.NewSubscriptionService(subscriptionRepo, categoryService)
 	tagService := service.NewTagService(tagRepo)
 	settingsService := service.NewSettingsService(settingsRepo)

--- a/internal/handlers/analytics_template_test.go
+++ b/internal/handlers/analytics_template_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"bytes"
+	"html/template"
+	"path/filepath"
+	"testing"
+
+	"subtrackr/internal/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderAnalyticsTemplate(t *testing.T, stats *models.Stats) string {
+	t.Helper()
+
+	tmpl, err := template.New("analytics.html").Funcs(template.FuncMap{
+		"t":   func(_ interface{}, key string) string { return key },
+		"mul": func(a, b float64) float64 { return a * b },
+		"div": func(a, b float64) float64 {
+			if b == 0 {
+				return 0
+			}
+			return a / b
+		},
+	}).ParseFiles(filepath.Join("..", "..", "templates", "analytics.html"))
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	require.NoError(t, tmpl.ExecuteTemplate(&output, "analytics.html", map[string]interface{}{
+		"Title":          "Analytics",
+		"Lang":           "en",
+		"CurrencySymbol": "kr",
+		"Stats":          stats,
+	}))
+	return output.String()
+}
+
+func renderDashboardTemplate(t *testing.T, stats *models.Stats) string {
+	t.Helper()
+
+	tmpl, err := template.New("dashboard.html").Funcs(template.FuncMap{
+		"t":   func(_ interface{}, key string) string { return key },
+		"mul": func(a, b float64) float64 { return a * b },
+		"div": func(a, b float64) float64 {
+			if b == 0 {
+				return 0
+			}
+			return a / b
+		},
+		"statusLabel":   func(_ interface{}, status string) string { return status },
+		"scheduleLabel": func(_ interface{}, schedule string, _ int) string { return schedule },
+	}).ParseFiles(filepath.Join("..", "..", "templates", "dashboard.html"))
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	require.NoError(t, tmpl.ExecuteTemplate(&output, "dashboard.html", map[string]interface{}{
+		"Title":          "Dashboard",
+		"Lang":           "en",
+		"CurrencySymbol": "kr",
+		"Stats":          stats,
+		"Subscriptions":  []SubscriptionWithConversion{},
+	}))
+	return output.String()
+}
+
+func TestAnalyticsTemplate_GroupsCurrenciesWithoutPercentageBarsWhenConversionIsIncomplete(t *testing.T) {
+	output := renderAnalyticsTemplate(t, &models.Stats{
+		ActiveSubscriptions:    2,
+		CancelledSubscriptions: 1,
+		ConversionComplete:     false,
+		TotalsByCurrency: map[string]models.CurrencyTotals{
+			"SEK": {
+				TotalMonthlySpend:   20,
+				TotalAnnualSpend:    240,
+				ActiveSubscriptions: 1,
+			},
+			"USD": {
+				TotalMonthlySpend:      3,
+				TotalAnnualSpend:       36,
+				TotalSaved:             120,
+				MonthlySaved:           10,
+				ActiveSubscriptions:    1,
+				CancelledSubscriptions: 1,
+			},
+		},
+		CategorySpendingByCurrency: map[string]map[string]float64{
+			"Foreign": {"USD": 3},
+			"Local":   {"SEK": 20},
+		},
+	})
+
+	assert.Contains(t, output, "20.00 SEK")
+	assert.Contains(t, output, "3.00 USD")
+	assert.Contains(t, output, "240.00 SEK")
+	assert.Contains(t, output, "36.00 USD")
+	assert.Contains(t, output, "120.00 USD")
+	assert.Contains(t, output, "Foreign")
+	assert.Contains(t, output, "Local")
+	assert.NotContains(t, output, "style=\"width:")
+}
+
+func TestAnalyticsTemplate_ShowsConvertedAggregateAndPercentageBarsWhenConversionIsComplete(t *testing.T) {
+	output := renderAnalyticsTemplate(t, &models.Stats{
+		TotalMonthlySpend:  50,
+		TotalAnnualSpend:   600,
+		ConversionComplete: true,
+		CategorySpending: map[string]float64{
+			"Foreign": 30,
+			"Local":   20,
+		},
+	})
+
+	assert.Contains(t, output, "kr50.00")
+	assert.Contains(t, output, "kr600.00")
+	assert.Contains(t, output, "style=\"width:")
+	assert.NotContains(t, output, "20.00 SEK")
+}
+
+func TestDashboardTemplate_GroupsCurrenciesWithoutPercentageBarsWhenConversionIsIncomplete(t *testing.T) {
+	output := renderDashboardTemplate(t, &models.Stats{
+		ActiveSubscriptions: 2,
+		ConversionComplete:  false,
+		TotalsByCurrency: map[string]models.CurrencyTotals{
+			"SEK": {
+				TotalMonthlySpend:   20,
+				TotalAnnualSpend:    240,
+				ActiveSubscriptions: 1,
+			},
+			"USD": {
+				TotalMonthlySpend:   3,
+				TotalAnnualSpend:    36,
+				ActiveSubscriptions: 1,
+			},
+		},
+		CategorySpendingByCurrency: map[string]map[string]float64{
+			"Foreign": {"USD": 3},
+			"Local":   {"SEK": 20},
+		},
+	})
+
+	assert.Contains(t, output, "20.00 SEK")
+	assert.Contains(t, output, "3.00 USD")
+	assert.Contains(t, output, "Foreign")
+	assert.Contains(t, output, "Local")
+	assert.NotContains(t, output, "style=\"width:")
+}

--- a/internal/handlers/calendar_currency_test.go
+++ b/internal/handlers/calendar_currency_test.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"encoding/json"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"subtrackr/internal/i18n"
+	"subtrackr/internal/models"
+	"subtrackr/internal/repository"
+	"subtrackr/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+type calendarTestEvent struct {
+	Cost           float64 `json:"cost"`
+	CurrencySymbol string  `json:"currency_symbol"`
+}
+
+func newCalendarCurrencyTestRouter(t *testing.T, withRate bool) *gin.Engine {
+	t.Helper()
+	t.Setenv("FIXER_API_KEY", "")
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "calendar.db")), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Category{},
+		&models.Tag{},
+		&models.Subscription{},
+		&models.ExchangeRate{},
+		&models.Settings{},
+	))
+
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := service.NewSettingsService(settingsRepo)
+	require.NoError(t, settingsService.SetCurrency("SEK"))
+
+	exchangeRateRepo := repository.NewExchangeRateRepository(db)
+	if withRate {
+		saveEURRates(t, exchangeRateRepo, time.Now().Add(-time.Hour))
+	}
+
+	categoryService := service.NewCategoryService(repository.NewCategoryRepository(db))
+	subscriptionService := service.NewSubscriptionService(repository.NewSubscriptionRepository(db), categoryService)
+	renewalDate := time.Now().AddDate(0, 0, 1)
+	_, err = subscriptionService.Create(&models.Subscription{
+		Name:             "Foreign subscription",
+		Cost:             3,
+		OriginalCurrency: "USD",
+		Schedule:         "Monthly",
+		Status:           "Active",
+		RenewalDate:      &renewalDate,
+	})
+	require.NoError(t, err)
+
+	handler := NewSubscriptionHandler(
+		subscriptionService,
+		settingsService,
+		service.NewCurrencyService(exchangeRateRepo, settingsRepo),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		categoryService,
+		nil,
+		i18n.NewCatalog(),
+	)
+
+	router := gin.New()
+	router.SetHTMLTemplate(template.Must(template.New("calendar.html").Parse(`{{define "calendar.html"}}<script>{{.EventsByDate}}</script>{{end}}`)))
+	router.GET("/calendar", handler.Calendar)
+	return router
+}
+
+func getCalendarTestEvent(t *testing.T, router *gin.Engine) calendarTestEvent {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/calendar", nil))
+	require.Equal(t, http.StatusOK, recorder.Code)
+
+	var eventsByDate map[string][]calendarTestEvent
+	eventsJSON := strings.TrimSuffix(strings.TrimPrefix(recorder.Body.String(), "<script>"), "</script>")
+	require.NoError(t, json.Unmarshal([]byte(eventsJSON), &eventsByDate))
+	for _, events := range eventsByDate {
+		require.Len(t, events, 1)
+		return events[0]
+	}
+	t.Fatal("calendar response did not contain an event")
+	return calendarTestEvent{}
+}
+
+func TestCalendar_ConvertsForeignCostWhenRateExists(t *testing.T) {
+	event := getCalendarTestEvent(t, newCalendarCurrencyTestRouter(t, true))
+
+	assert.InDelta(t, 30, event.Cost, 0.001)
+	assert.Equal(t, "kr", event.CurrencySymbol)
+}
+
+func TestCalendar_UsesOriginalCurrencyWhenRateIsMissing(t *testing.T) {
+	event := getCalendarTestEvent(t, newCalendarCurrencyTestRouter(t, false))
+
+	assert.InDelta(t, 3, event.Cost, 0.001)
+	assert.Equal(t, "$", event.CurrencySymbol)
+}

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -302,22 +302,29 @@ func (h *SubscriptionHandler) Calendar(c *gin.Context) {
 	// Filter subscriptions with renewal dates and group by date
 	// Create a simplified structure for JavaScript
 	type Event struct {
-		Name    string  `json:"name"`
-		Cost    float64 `json:"cost"`
-		ID      uint    `json:"id"`
-		IconURL string  `json:"icon_url"`
+		Name           string  `json:"name"`
+		Cost           float64 `json:"cost"`
+		CurrencySymbol string  `json:"currency_symbol"`
+		ID             uint    `json:"id"`
+		IconURL        string  `json:"icon_url"`
 	}
-	eventsByDate := make(map[string][]Event)
+	calendarSubscriptions := make([]models.Subscription, 0, len(subscriptions))
 	for _, sub := range subscriptions {
 		if sub.RenewalDate != nil && sub.Status == "Active" {
-			dateKey := sub.RenewalDate.Format("2006-01-02")
-			eventsByDate[dateKey] = append(eventsByDate[dateKey], Event{
-				Name:    sub.Name,
-				Cost:    sub.Cost,
-				ID:      sub.ID,
-				IconURL: sub.IconURL,
-			})
+			calendarSubscriptions = append(calendarSubscriptions, sub)
 		}
+	}
+
+	eventsByDate := make(map[string][]Event)
+	for _, sub := range h.enrichWithCurrencyConversion(calendarSubscriptions) {
+		dateKey := sub.RenewalDate.Format("2006-01-02")
+		eventsByDate[dateKey] = append(eventsByDate[dateKey], Event{
+			Name:           sub.Name,
+			Cost:           sub.ConvertedCost,
+			CurrencySymbol: sub.DisplayCurrencySymbol,
+			ID:             sub.ID,
+			IconURL:        sub.IconURL,
+		})
 	}
 
 	// Get current month/year or from query params
@@ -384,7 +391,6 @@ func (h *SubscriptionHandler) Calendar(c *gin.Context) {
 		"FirstOfMonth":            firstOfMonth,
 		"PrevMonth":               prevMonth,
 		"NextMonth":               nextMonth,
-		"CurrencySymbol":          h.settingsService.GetCurrencySymbol(),
 		"DarkMode":                h.settingsService.IsDarkModeEnabled(),
 		"ICalSubscriptionEnabled": icalSubscriptionEnabled,
 		"ICalSubscriptionURL":     icalSubscriptionURL,

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -965,6 +965,13 @@ func (h *SubscriptionHandler) GetStats(c *gin.Context) {
 	c.JSON(http.StatusOK, stats)
 }
 
+func subscriptionFormCurrency(subscription *models.Subscription, preferredCurrency string) string {
+	if subscription != nil && subscription.OriginalCurrency != "" {
+		return subscription.OriginalCurrency
+	}
+	return preferredCurrency
+}
+
 // GetSubscriptionForm returns the subscription form (for add/edit)
 func (h *SubscriptionHandler) GetSubscriptionForm(c *gin.Context) {
 	var subscription *models.Subscription
@@ -996,11 +1003,13 @@ func (h *SubscriptionHandler) GetSubscriptionForm(c *gin.Context) {
 		}
 		tagsCSV = strings.Join(names, ", ")
 	}
+	formCurrency := subscriptionFormCurrency(subscription, h.settingsService.GetCurrency())
 
 	c.HTML(http.StatusOK, "subscription-form.html", gin.H{
 		"Subscription":   subscription,
 		"IsEdit":         isEdit,
-		"CurrencySymbol": h.settingsService.GetCurrencySymbol(),
+		"CurrencySymbol": service.CurrencySymbolForCode(formCurrency),
+		"FormCurrency":   formCurrency,
 		"Categories":     categories,
 		"Currencies":     service.GetAvailableCurrencies(),
 		"TagsCSV":        tagsCSV,

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -22,13 +22,15 @@ import (
 // SubscriptionWithConversion represents a subscription with currency conversion info
 type SubscriptionWithConversion struct {
 	*models.Subscription
-	ConvertedCost         float64 `json:"converted_cost"`
-	ConvertedAnnualCost   float64 `json:"converted_annual_cost"`
-	ConvertedMonthlyCost  float64 `json:"converted_monthly_cost"`
-	ConvertedShareCost    float64 `json:"converted_share_cost"` // Per-period cost in display currency, after share split
-	DisplayCurrency       string  `json:"display_currency"`
-	DisplayCurrencySymbol string  `json:"display_currency_symbol"`
-	ShowConversion        bool    `json:"show_conversion"`
+	ConvertedCost         float64   `json:"converted_cost"`
+	ConvertedAnnualCost   float64   `json:"converted_annual_cost"`
+	ConvertedMonthlyCost  float64   `json:"converted_monthly_cost"`
+	ConvertedShareCost    float64   `json:"converted_share_cost"` // Per-period cost in display currency, after share split
+	DisplayCurrency       string    `json:"display_currency"`
+	DisplayCurrencySymbol string    `json:"display_currency_symbol"`
+	ShowConversion        bool      `json:"show_conversion"`
+	ConversionRateDate    time.Time `json:"conversion_rate_date"`
+	ConversionRateStale   bool      `json:"conversion_rate_stale"`
 }
 
 type SubscriptionHandler struct {
@@ -88,23 +90,26 @@ func (h *SubscriptionHandler) enrichWithCurrencyConversion(subscriptions []model
 			ShowConversion:        false,
 		}
 
-		if h.currencyService.IsEnabled() && sub.OriginalCurrency != "" && sub.OriginalCurrency != displayCurrency {
-			if convertedCost, err := h.currencyService.ConvertAmount(sub.Cost, sub.OriginalCurrency, displayCurrency); err == nil {
-				enriched.ConvertedCost = convertedCost.Amount
-				ratio := convertedCost.Amount / sub.Cost
-				enriched.ConvertedAnnualCost = sub.AnnualCost() * ratio
-				enriched.ConvertedMonthlyCost = sub.MonthlyCost() * ratio
-				enriched.ConvertedShareCost = sub.MyShareCost() * ratio
+		if sub.OriginalCurrency != "" && sub.OriginalCurrency != displayCurrency {
+			if conversion, err := h.currencyService.ConvertAmount(1, sub.OriginalCurrency, displayCurrency); err == nil {
+				rate := conversion.Amount
+				enriched.ConvertedCost = sub.Cost * rate
+				enriched.ConvertedAnnualCost = sub.AnnualCost() * rate
+				enriched.ConvertedMonthlyCost = sub.MonthlyCost() * rate
+				enriched.ConvertedShareCost = sub.MyShareCost() * rate
 				enriched.ShowConversion = true
+				enriched.ConversionRateDate = conversion.RateDate
+				enriched.ConversionRateStale = conversion.Stale
+			} else {
+				// Without a usable rate, presenting the original amount avoids labeling
+				// one currency's value with another currency's symbol.
+				enriched.ConvertedCost = sub.Cost
+				enriched.ConvertedAnnualCost = sub.AnnualCost()
+				enriched.ConvertedMonthlyCost = sub.MonthlyCost()
+				enriched.ConvertedShareCost = sub.MyShareCost()
+				enriched.DisplayCurrency = sub.OriginalCurrency
+				enriched.DisplayCurrencySymbol = service.CurrencySymbolForCode(sub.OriginalCurrency)
 			}
-		} else if sub.OriginalCurrency != "" && sub.OriginalCurrency != displayCurrency {
-			// Different currency but conversion not available - show original currency
-			enriched.ConvertedCost = sub.Cost
-			enriched.ConvertedAnnualCost = sub.AnnualCost()
-			enriched.ConvertedMonthlyCost = sub.MonthlyCost()
-			enriched.ConvertedShareCost = sub.MyShareCost()
-			enriched.DisplayCurrency = sub.OriginalCurrency
-			enriched.DisplayCurrencySymbol = service.CurrencySymbolForCode(sub.OriginalCurrency)
 		} else {
 			// Same currency or no conversion needed
 			enriched.ConvertedCost = sub.Cost
@@ -129,19 +134,19 @@ func (h *SubscriptionHandler) isHighCostWithCurrency(subscription *models.Subscr
 	// Get monthly cost in subscription's original currency
 	monthlyCost := subscription.MonthlyCost()
 
-	// If currencies match or conversion is disabled, compare directly
-	if subscription.OriginalCurrency == displayCurrency || !h.currencyService.IsEnabled() {
+	// Subscriptions without an original currency predate currency tracking and
+	// retain the existing assumption that their cost uses the display currency.
+	if subscription.OriginalCurrency == "" || subscription.OriginalCurrency == displayCurrency {
 		return monthlyCost > threshold
 	}
 
 	// Convert monthly cost to display currency
 	convertedMonthlyCost, err := h.currencyService.ConvertAmount(monthlyCost, subscription.OriginalCurrency, displayCurrency)
 	if err != nil {
-		// If conversion fails, fall back to direct comparison
-		// Note: This may not be accurate if currencies differ, but prevents silent failures
-		// The warning log helps identify when this fallback is used
-		log.Printf("Warning: Failed to convert currency for high-cost check (%s to %s): %v. Using direct comparison.", subscription.OriginalCurrency, displayCurrency, err)
-		return monthlyCost > threshold
+		// Comparing unlike currencies can produce a false alert, so defer the
+		// classification until a conversion rate is available.
+		log.Printf("Warning: Failed to convert currency for high-cost check (%s to %s): %v", subscription.OriginalCurrency, displayCurrency, err)
+		return false
 	}
 
 	// Compare converted monthly cost against threshold
@@ -548,37 +553,37 @@ func (h *SubscriptionHandler) Settings(c *gin.Context) {
 	}
 
 	c.HTML(http.StatusOK, "settings.html", gin.H{
-		"Title":                    "Settings",
-		"CurrentPage":              "settings",
-		"Currency":                 h.settingsService.GetCurrency(),
-		"CurrencySymbol":           h.settingsService.GetCurrencySymbol(),
-		"RenewalReminders":         h.settingsService.GetBoolSettingWithDefault("renewal_reminders", false),
-		"HighCostAlerts":           h.settingsService.GetBoolSettingWithDefault("high_cost_alerts", true),
-		"PushoverConfig":           pushoverConfig,
-		"PushoverConfigured":       pushoverConfigured,
-		"HighCostThreshold":        h.settingsService.GetFloatSettingWithDefault("high_cost_threshold", 50.0),
+		"Title":                        "Settings",
+		"CurrentPage":                  "settings",
+		"Currency":                     h.settingsService.GetCurrency(),
+		"CurrencySymbol":               h.settingsService.GetCurrencySymbol(),
+		"RenewalReminders":             h.settingsService.GetBoolSettingWithDefault("renewal_reminders", false),
+		"HighCostAlerts":               h.settingsService.GetBoolSettingWithDefault("high_cost_alerts", true),
+		"PushoverConfig":               pushoverConfig,
+		"PushoverConfigured":           pushoverConfigured,
+		"HighCostThreshold":            h.settingsService.GetFloatSettingWithDefault("high_cost_threshold", 50.0),
 		"ReminderDays":                 h.settingsService.GetIntSettingWithDefault("reminder_days", 7),
 		"ReminderDaysList":             h.settingsService.GetStringSettingWithDefault("reminder_days_list", ""),
 		"CancellationReminders":        h.settingsService.GetBoolSettingWithDefault("cancellation_reminders", false),
 		"CancellationReminderDays":     h.settingsService.GetIntSettingWithDefault("cancellation_reminder_days", 7),
 		"CancellationReminderDaysList": h.settingsService.GetStringSettingWithDefault("cancellation_reminder_days_list", ""),
-		"DarkMode":                 h.settingsService.IsDarkModeEnabled(),
-		"Version":                  version.GetVersion(),
-		"SMTPConfig":               smtpConfig,
-		"SMTPConfigured":           smtpConfigured,
-		"AuthEnabled":              authEnabled,
-		"AuthUsername":             authUsername,
-		"ICalSubscriptionEnabled":  icalSubscriptionEnabled,
-		"ICalSubscriptionURL":      icalSubscriptionURL,
-		"BaseURL":                  h.settingsService.GetBaseURL(),
-		"Currencies":               service.GetAvailableCurrencies(),
-		"DateFormat":               h.settingsService.GetDateFormat(),
-		"WebhookConfig":            webhookConfig,
-		"WebhookConfigured":        webhookConfigured,
-		"TelegramConfig":           telegramConfig,
-		"TelegramConfigured":       telegramConfigured,
-		"Lang":                     h.activeLang(),
-		"Languages":                h.i18nCatalog.AvailableLanguages(),
+		"DarkMode":                     h.settingsService.IsDarkModeEnabled(),
+		"Version":                      version.GetVersion(),
+		"SMTPConfig":                   smtpConfig,
+		"SMTPConfigured":               smtpConfigured,
+		"AuthEnabled":                  authEnabled,
+		"AuthUsername":                 authUsername,
+		"ICalSubscriptionEnabled":      icalSubscriptionEnabled,
+		"ICalSubscriptionURL":          icalSubscriptionURL,
+		"BaseURL":                      h.settingsService.GetBaseURL(),
+		"Currencies":                   service.GetAvailableCurrencies(),
+		"DateFormat":                   h.settingsService.GetDateFormat(),
+		"WebhookConfig":                webhookConfig,
+		"WebhookConfigured":            webhookConfigured,
+		"TelegramConfig":               telegramConfig,
+		"TelegramConfigured":           telegramConfigured,
+		"Lang":                         h.activeLang(),
+		"Languages":                    h.i18nCatalog.AvailableLanguages(),
 	})
 }
 

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -90,8 +90,8 @@ func (h *SubscriptionHandler) enrichWithCurrencyConversion(subscriptions []model
 
 		if h.currencyService.IsEnabled() && sub.OriginalCurrency != "" && sub.OriginalCurrency != displayCurrency {
 			if convertedCost, err := h.currencyService.ConvertAmount(sub.Cost, sub.OriginalCurrency, displayCurrency); err == nil {
-				enriched.ConvertedCost = convertedCost
-				ratio := convertedCost / sub.Cost
+				enriched.ConvertedCost = convertedCost.Amount
+				ratio := convertedCost.Amount / sub.Cost
 				enriched.ConvertedAnnualCost = sub.AnnualCost() * ratio
 				enriched.ConvertedMonthlyCost = sub.MonthlyCost() * ratio
 				enriched.ConvertedShareCost = sub.MyShareCost() * ratio
@@ -145,7 +145,7 @@ func (h *SubscriptionHandler) isHighCostWithCurrency(subscription *models.Subscr
 	}
 
 	// Compare converted monthly cost against threshold
-	return convertedMonthlyCost > threshold
+	return convertedMonthlyCost.Amount > threshold
 }
 
 // fetchAndSetLogo fetches a logo for a subscription if URL is provided and icon_url is empty

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"subtrackr/internal/i18n"
@@ -126,6 +127,52 @@ func (h *SubscriptionHandler) enrichWithCurrencyConversion(subscriptions []model
 	}
 
 	return result
+}
+
+func sortSubscriptionsByCost(subscriptions []SubscriptionWithConversion, preferredCurrency, order string) {
+	if order != "asc" && order != "desc" {
+		order = "desc"
+	}
+	sort.SliceStable(subscriptions, func(i, j int) bool {
+		left := subscriptions[i]
+		right := subscriptions[j]
+
+		if left.DisplayCurrency != right.DisplayCurrency {
+			if left.DisplayCurrency == preferredCurrency {
+				return true
+			}
+			if right.DisplayCurrency == preferredCurrency {
+				return false
+			}
+			return left.DisplayCurrency < right.DisplayCurrency
+		}
+
+		if left.ConvertedCost == right.ConvertedCost {
+			return left.Name < right.Name
+		}
+		if order == "desc" {
+			return left.ConvertedCost > right.ConvertedCost
+		}
+		return left.ConvertedCost < right.ConvertedCost
+	})
+}
+
+func (h *SubscriptionHandler) getSubscriptionsForDisplay(sortBy, order string) ([]SubscriptionWithConversion, error) {
+	if sortBy == "cost" {
+		subscriptions, err := h.service.GetAll()
+		if err != nil {
+			return nil, err
+		}
+		enriched := h.enrichWithCurrencyConversion(subscriptions)
+		sortSubscriptionsByCost(enriched, h.settingsService.GetCurrency(), order)
+		return enriched, nil
+	}
+
+	subscriptions, err := h.service.GetAllSorted(sortBy, order)
+	if err != nil {
+		return nil, err
+	}
+	return h.enrichWithCurrencyConversion(subscriptions), nil
 }
 
 // isHighCostWithCurrency checks if a subscription is high-cost, respecting currency conversion
@@ -250,14 +297,11 @@ func (h *SubscriptionHandler) SubscriptionsList(c *gin.Context) {
 	order := c.DefaultQuery("order", "desc")
 
 	// Get sorted subscriptions
-	subscriptions, err := h.service.GetAllSorted(sortBy, order)
+	enrichedSubs, err := h.getSubscriptionsForDisplay(sortBy, order)
 	if err != nil {
 		c.HTML(http.StatusInternalServerError, "error.html", gin.H{"error": err.Error()})
 		return
 	}
-
-	// Enrich with currency conversion
-	enrichedSubs := h.enrichWithCurrencyConversion(subscriptions)
 
 	c.HTML(http.StatusOK, "subscriptions.html", gin.H{
 		"Title":          "Subscriptions",
@@ -606,14 +650,11 @@ func (h *SubscriptionHandler) GetSubscriptions(c *gin.Context) {
 	order := c.DefaultQuery("order", "desc")
 
 	// Get sorted subscriptions
-	subscriptions, err := h.service.GetAllSorted(sortBy, order)
+	enrichedSubs, err := h.getSubscriptionsForDisplay(sortBy, order)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-
-	// Enrich with currency conversion
-	enrichedSubs := h.enrichWithCurrencyConversion(subscriptions)
 
 	c.HTML(http.StatusOK, "subscription-list.html", gin.H{
 		"Subscriptions":  enrichedSubs,

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -63,6 +63,10 @@ func NewSubscriptionHandler(service *service.SubscriptionService, settingsServic
 	}
 }
 
+func (h *SubscriptionHandler) getStats() (*models.Stats, error) {
+	return h.service.GetStats(h.currencyService, h.settingsService.GetCurrency())
+}
+
 // activeLang resolves the user-preferred language code, defaulting to "en" when unset
 // or when the requested language has no loaded translations.
 func (h *SubscriptionHandler) activeLang() string {
@@ -213,7 +217,7 @@ func parseDatePtr(dateStr string) *time.Time {
 
 // Dashboard renders the main dashboard page
 func (h *SubscriptionHandler) Dashboard(c *gin.Context) {
-	stats, err := h.service.GetStats()
+	stats, err := h.getStats()
 	if err != nil {
 		c.HTML(http.StatusInternalServerError, "error.html", gin.H{"error": err.Error()})
 		return
@@ -270,7 +274,7 @@ func (h *SubscriptionHandler) SubscriptionsList(c *gin.Context) {
 
 // Analytics renders the analytics page
 func (h *SubscriptionHandler) Analytics(c *gin.Context) {
-	stats, err := h.service.GetStats()
+	stats, err := h.getStats()
 	if err != nil {
 		c.HTML(http.StatusInternalServerError, "error.html", gin.H{"error": err.Error()})
 		return
@@ -961,7 +965,7 @@ func (h *SubscriptionHandler) DeleteSubscription(c *gin.Context) {
 
 // GetStats returns current statistics
 func (h *SubscriptionHandler) GetStats(c *gin.Context) {
-	stats, err := h.service.GetStats()
+	stats, err := h.getStats()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -1099,7 +1103,7 @@ func (h *SubscriptionHandler) BackupData(c *gin.Context) {
 		return
 	}
 
-	stats, err := h.service.GetStats()
+	stats, err := h.getStats()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/handlers/subscription_currency_test.go
+++ b/internal/handlers/subscription_currency_test.go
@@ -123,6 +123,35 @@ func TestEnrichWithCurrencyConversion_UsesOriginalCurrencyWhenNoRateExists(t *te
 	assert.Equal(t, 36.0, result[0].ConvertedAnnualCost)
 }
 
+func TestSortSubscriptionsByCost_UsesConvertedValuesWhenRatesExist(t *testing.T) {
+	handler, exchangeRateRepo, _ := newCurrencyTestHandler(t)
+	saveEURRates(t, exchangeRateRepo, time.Now().Add(-time.Hour))
+
+	subscriptions := handler.enrichWithCurrencyConversion([]models.Subscription{
+		{Name: "Foreign", Cost: 3, Schedule: "Monthly", OriginalCurrency: "USD"},
+		{Name: "Local", Cost: 20, Schedule: "Monthly", OriginalCurrency: "SEK"},
+	})
+	sortSubscriptionsByCost(subscriptions, "SEK", "asc")
+
+	assert.Equal(t, []string{"Local", "Foreign"}, []string{subscriptions[0].Name, subscriptions[1].Name})
+}
+
+func TestSortSubscriptionsByCost_GroupsMissingRatesAndSortsWithinCurrencies(t *testing.T) {
+	handler, _, _ := newCurrencyTestHandler(t)
+	subscriptions := handler.enrichWithCurrencyConversion([]models.Subscription{
+		{Name: "USD 3", Cost: 3, Schedule: "Monthly", OriginalCurrency: "USD"},
+		{Name: "SEK 20", Cost: 20, Schedule: "Monthly", OriginalCurrency: "SEK"},
+		{Name: "USD 1", Cost: 1, Schedule: "Monthly", OriginalCurrency: "USD"},
+		{Name: "SEK 10", Cost: 10, Schedule: "Monthly", OriginalCurrency: "SEK"},
+	})
+	sortSubscriptionsByCost(subscriptions, "SEK", "desc")
+
+	assert.Equal(t,
+		[]string{"SEK 20", "SEK 10", "USD 3", "USD 1"},
+		[]string{subscriptions[0].Name, subscriptions[1].Name, subscriptions[2].Name, subscriptions[3].Name},
+	)
+}
+
 func TestIsHighCostWithCurrency_DoesNotCompareUnconvertedCurrencies(t *testing.T) {
 	handler, _, settingsService := newCurrencyTestHandler(t)
 	require.NoError(t, settingsService.SetFloatSetting("high_cost_threshold", 50))

--- a/internal/handlers/subscription_currency_test.go
+++ b/internal/handlers/subscription_currency_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"bytes"
+	"log"
+	"testing"
+	"time"
+
+	"subtrackr/internal/models"
+	"subtrackr/internal/repository"
+	"subtrackr/internal/service"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newCurrencyTestHandler(t *testing.T) (*SubscriptionHandler, *repository.ExchangeRateRepository, *service.SettingsService) {
+	t.Helper()
+	t.Setenv("FIXER_API_KEY", "")
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ExchangeRate{}, &models.Settings{}))
+
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := service.NewSettingsService(settingsRepo)
+	require.NoError(t, settingsService.SetCurrency("SEK"))
+
+	exchangeRateRepo := repository.NewExchangeRateRepository(db)
+	currencyService := service.NewCurrencyService(exchangeRateRepo, settingsRepo)
+
+	return &SubscriptionHandler{
+		settingsService: settingsService,
+		currencyService: currencyService,
+	}, exchangeRateRepo, settingsService
+}
+
+func saveEURRates(t *testing.T, repo *repository.ExchangeRateRepository, rateDate time.Time) {
+	t.Helper()
+	require.NoError(t, repo.SaveRates([]models.ExchangeRate{
+		{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: rateDate},
+		{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: rateDate},
+	}))
+}
+
+func TestEnrichWithCurrencyConversion_UsesFreshCachedCrossRateWithoutAPIKey(t *testing.T) {
+	handler, exchangeRateRepo, _ := newCurrencyTestHandler(t)
+	rateDate := time.Now().Add(-time.Hour)
+	saveEURRates(t, exchangeRateRepo, rateDate)
+
+	result := handler.enrichWithCurrencyConversion([]models.Subscription{{
+		Cost:             3,
+		Schedule:         "Monthly",
+		OriginalCurrency: "USD",
+	}})
+
+	require.Len(t, result, 1)
+	assert.True(t, result[0].ShowConversion)
+	assert.Equal(t, "SEK", result[0].DisplayCurrency)
+	assert.Equal(t, "kr", result[0].DisplayCurrencySymbol)
+	assert.InDelta(t, 30, result[0].ConvertedCost, 0.001)
+	assert.WithinDuration(t, rateDate, result[0].ConversionRateDate, time.Millisecond)
+	assert.False(t, result[0].ConversionRateStale)
+}
+
+func TestEnrichWithCurrencyConversion_ConvertsZeroCostWithoutInvalidValues(t *testing.T) {
+	handler, exchangeRateRepo, _ := newCurrencyTestHandler(t)
+	saveEURRates(t, exchangeRateRepo, time.Now().Add(-time.Hour))
+
+	result := handler.enrichWithCurrencyConversion([]models.Subscription{{
+		Cost:             0,
+		Schedule:         "Monthly",
+		ShareCount:       2,
+		OriginalCurrency: "USD",
+	}})
+
+	require.Len(t, result, 1)
+	assert.True(t, result[0].ShowConversion)
+	assert.Equal(t, 0.0, result[0].ConvertedCost)
+	assert.Equal(t, 0.0, result[0].ConvertedAnnualCost)
+	assert.Equal(t, 0.0, result[0].ConvertedMonthlyCost)
+	assert.Equal(t, 0.0, result[0].ConvertedShareCost)
+}
+
+func TestEnrichWithCurrencyConversion_UsesStaleCachedRateWithTimestamp(t *testing.T) {
+	handler, exchangeRateRepo, _ := newCurrencyTestHandler(t)
+	rateDate := time.Now().Add(-5 * 24 * time.Hour)
+	saveEURRates(t, exchangeRateRepo, rateDate)
+
+	result := handler.enrichWithCurrencyConversion([]models.Subscription{{
+		Cost:             3,
+		Schedule:         "Monthly",
+		OriginalCurrency: "USD",
+	}})
+
+	require.Len(t, result, 1)
+	assert.True(t, result[0].ShowConversion)
+	assert.InDelta(t, 30, result[0].ConvertedCost, 0.001)
+	assert.WithinDuration(t, rateDate, result[0].ConversionRateDate, time.Millisecond)
+	assert.True(t, result[0].ConversionRateStale)
+}
+
+func TestEnrichWithCurrencyConversion_UsesOriginalCurrencyWhenNoRateExists(t *testing.T) {
+	handler, _, _ := newCurrencyTestHandler(t)
+
+	result := handler.enrichWithCurrencyConversion([]models.Subscription{{
+		Cost:             3,
+		Schedule:         "Monthly",
+		OriginalCurrency: "USD",
+	}})
+
+	require.Len(t, result, 1)
+	assert.False(t, result[0].ShowConversion)
+	assert.Equal(t, "USD", result[0].DisplayCurrency)
+	assert.Equal(t, "$", result[0].DisplayCurrencySymbol)
+	assert.Equal(t, 3.0, result[0].ConvertedCost)
+	assert.Equal(t, 3.0, result[0].ConvertedMonthlyCost)
+	assert.Equal(t, 36.0, result[0].ConvertedAnnualCost)
+}
+
+func TestIsHighCostWithCurrency_DoesNotCompareUnconvertedCurrencies(t *testing.T) {
+	handler, _, settingsService := newCurrencyTestHandler(t)
+	require.NoError(t, settingsService.SetFloatSetting("high_cost_threshold", 50))
+
+	var logs bytes.Buffer
+	originalLogOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(originalLogOutput) })
+
+	isHighCost := handler.isHighCostWithCurrency(&models.Subscription{
+		Cost:             100,
+		Schedule:         "Monthly",
+		OriginalCurrency: "USD",
+	})
+
+	assert.False(t, isHighCost)
+	assert.Contains(t, logs.String(), "Failed to convert currency for high-cost check (USD to SEK)")
+	assert.NotContains(t, logs.String(), "Using direct comparison")
+}

--- a/internal/handlers/subscription_form_test.go
+++ b/internal/handlers/subscription_form_test.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"subtrackr/internal/database"
+	"subtrackr/internal/repository"
+	"subtrackr/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestGetSubscriptionForm_Integration_UsesPreferredCurrency(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, database.RunMigrations(db))
+
+	settingsService := service.NewSettingsService(repository.NewSettingsRepository(db))
+	require.NoError(t, settingsService.SetCurrency("SEK"))
+
+	categoryService := service.NewCategoryService(repository.NewCategoryRepository(db))
+	subscriptionService := service.NewSubscriptionService(repository.NewSubscriptionRepository(db), categoryService)
+	handler := NewSubscriptionHandler(
+		subscriptionService,
+		settingsService,
+		service.NewCurrencyService(repository.NewExchangeRateRepository(db)),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		categoryService,
+		nil,
+		nil,
+	)
+
+	formTemplate := template.Must(template.New("subscription-form.html").Funcs(template.FuncMap{
+		"t": func(_ interface{}, key string) string { return key },
+	}).ParseFiles("../../templates/subscription-form.html"))
+	router := gin.New()
+	router.SetHTMLTemplate(formTemplate)
+	router.GET("/form/subscription", handler.GetSubscriptionForm)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/form/subscription", nil)
+	router.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusOK, recorder.Code, "body: %s", recorder.Body.String())
+	assert.Contains(t, recorder.Body.String(), `<option value="SEK" data-symbol="kr" selected>kr SEK</option>`)
+	assert.NotContains(t, recorder.Body.String(), `<option value="USD" data-symbol="$" selected>$ USD</option>`)
+}

--- a/internal/handlers/subscription_form_test.go
+++ b/internal/handlers/subscription_form_test.go
@@ -24,7 +24,8 @@ func TestGetSubscriptionForm_Integration_UsesPreferredCurrency(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, database.RunMigrations(db))
 
-	settingsService := service.NewSettingsService(repository.NewSettingsRepository(db))
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := service.NewSettingsService(settingsRepo)
 	require.NoError(t, settingsService.SetCurrency("SEK"))
 
 	categoryService := service.NewCategoryService(repository.NewCategoryRepository(db))
@@ -32,7 +33,7 @@ func TestGetSubscriptionForm_Integration_UsesPreferredCurrency(t *testing.T) {
 	handler := NewSubscriptionHandler(
 		subscriptionService,
 		settingsService,
-		service.NewCurrencyService(repository.NewExchangeRateRepository(db)),
+		service.NewCurrencyService(repository.NewExchangeRateRepository(db), settingsRepo),
 		nil,
 		nil,
 		nil,

--- a/internal/handlers/subscription_reminder_test.go
+++ b/internal/handlers/subscription_reminder_test.go
@@ -32,8 +32,9 @@ func newReminderTestRouter(t *testing.T) (*gin.Engine, *service.SubscriptionServ
 	subscriptionRepo := repository.NewSubscriptionRepository(db)
 	categoryService := service.NewCategoryService(repository.NewCategoryRepository(db))
 	subscriptionService := service.NewSubscriptionService(subscriptionRepo, categoryService)
-	settingsService := service.NewSettingsService(repository.NewSettingsRepository(db))
-	currencyService := service.NewCurrencyService(repository.NewExchangeRateRepository(db))
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := service.NewSettingsService(settingsRepo)
+	currencyService := service.NewCurrencyService(repository.NewExchangeRateRepository(db), settingsRepo)
 
 	handler := NewSubscriptionHandler(
 		subscriptionService,

--- a/internal/handlers/subscription_test.go
+++ b/internal/handlers/subscription_test.go
@@ -4,8 +4,43 @@ import (
 	"testing"
 	"time"
 
+	"subtrackr/internal/models"
+
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSubscriptionFormCurrency(t *testing.T) {
+	tests := []struct {
+		name              string
+		subscription      *models.Subscription
+		preferredCurrency string
+		expected          string
+	}{
+		{
+			name:              "new subscription uses preferred currency",
+			preferredCurrency: "SEK",
+			expected:          "SEK",
+		},
+		{
+			name:              "existing subscription uses original currency",
+			subscription:      &models.Subscription{OriginalCurrency: "USD"},
+			preferredCurrency: "SEK",
+			expected:          "USD",
+		},
+		{
+			name:              "existing subscription without currency uses preferred currency",
+			subscription:      &models.Subscription{},
+			preferredCurrency: "SEK",
+			expected:          "SEK",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, subscriptionFormCurrency(tt.subscription, tt.preferredCurrency))
+		})
+	}
+}
 
 func TestParseDatePtr(t *testing.T) {
 	tests := []struct {
@@ -105,4 +140,3 @@ func TestParseDatePtr(t *testing.T) {
 func timePtr(t time.Time) *time.Time {
 	return &t
 }
-

--- a/internal/handlers/wallos_import_test.go
+++ b/internal/handlers/wallos_import_test.go
@@ -41,8 +41,9 @@ func newWallosTestHandler(t *testing.T) (*gin.Engine, *service.SubscriptionServi
 
 	categoryService := service.NewCategoryService(repository.NewCategoryRepository(db))
 	subscriptionService := service.NewSubscriptionService(repository.NewSubscriptionRepository(db), categoryService)
-	settingsService := service.NewSettingsService(repository.NewSettingsRepository(db))
-	currencyService := service.NewCurrencyService(repository.NewExchangeRateRepository(db))
+	settingsRepo := repository.NewSettingsRepository(db)
+	settingsService := service.NewSettingsService(settingsRepo)
+	currencyService := service.NewCurrencyService(repository.NewExchangeRateRepository(db), settingsRepo)
 
 	handler := NewSubscriptionHandler(
 		subscriptionService,

--- a/internal/models/subscription.go
+++ b/internal/models/subscription.go
@@ -481,14 +481,26 @@ func (s *Subscription) calculateNextRenewalDateFromNowV2() {
 
 // Stats represents aggregated subscription statistics
 type Stats struct {
-	TotalMonthlySpend      float64            `json:"total_monthly_spend"`
-	TotalAnnualSpend       float64            `json:"total_annual_spend"`
-	ActiveSubscriptions    int                `json:"active_subscriptions"`
-	CancelledSubscriptions int                `json:"cancelled_subscriptions"`
-	TotalSaved             float64            `json:"total_saved"`
-	MonthlySaved           float64            `json:"monthly_saved"`
-	UpcomingRenewals       int                `json:"upcoming_renewals"`
-	CategorySpending       map[string]float64 `json:"category_spending"`
+	TotalMonthlySpend          float64                       `json:"total_monthly_spend"`
+	TotalAnnualSpend           float64                       `json:"total_annual_spend"`
+	ActiveSubscriptions        int                           `json:"active_subscriptions"`
+	CancelledSubscriptions     int                           `json:"cancelled_subscriptions"`
+	TotalSaved                 float64                       `json:"total_saved"`
+	MonthlySaved               float64                       `json:"monthly_saved"`
+	UpcomingRenewals           int                           `json:"upcoming_renewals"`
+	CategorySpending           map[string]float64            `json:"category_spending"`
+	ConversionComplete         bool                          `json:"conversion_complete"`
+	TotalsByCurrency           map[string]CurrencyTotals     `json:"totals_by_currency"`
+	CategorySpendingByCurrency map[string]map[string]float64 `json:"category_spending_by_currency"`
+}
+
+type CurrencyTotals struct {
+	TotalMonthlySpend      float64 `json:"total_monthly_spend"`
+	TotalAnnualSpend       float64 `json:"total_annual_spend"`
+	TotalSaved             float64 `json:"total_saved"`
+	MonthlySaved           float64 `json:"monthly_saved"`
+	ActiveSubscriptions    int     `json:"active_subscriptions"`
+	CancelledSubscriptions int     `json:"cancelled_subscriptions"`
 }
 
 // CategoryStat represents spending by category

--- a/internal/models/subscription.go
+++ b/internal/models/subscription.go
@@ -502,10 +502,3 @@ type CurrencyTotals struct {
 	ActiveSubscriptions    int     `json:"active_subscriptions"`
 	CancelledSubscriptions int     `json:"cancelled_subscriptions"`
 }
-
-// CategoryStat represents spending by category
-type CategoryStat struct {
-	Category string  `json:"category"`
-	Amount   float64 `json:"amount"`
-	Count    int     `json:"count"`
-}

--- a/internal/repository/subscription.go
+++ b/internal/repository/subscription.go
@@ -276,28 +276,3 @@ func (r *SubscriptionRepository) GetUpcomingCancellations(days int) ([]models.Su
 	}
 	return subscriptions, nil
 }
-
-func (r *SubscriptionRepository) GetCategoryStats() ([]models.CategoryStat, error) {
-	var stats []models.CategoryStat
-	// Divide by COALESCE(share_count,1) so shared subscriptions only count the user's share,
-	// matching the in-Go MonthlyCost/AnnualCost calculations.
-	if err := r.db.Table("subscriptions").
-		Select(`categories.name as category,
-			SUM(
-				CASE WHEN subscriptions.schedule = 'Annual'    THEN subscriptions.cost/12
-				     WHEN subscriptions.schedule = 'Quarterly' THEN subscriptions.cost/3
-				     WHEN subscriptions.schedule = 'Monthly'   THEN subscriptions.cost
-				     WHEN subscriptions.schedule = 'Weekly'    THEN subscriptions.cost*4.33
-				     WHEN subscriptions.schedule = 'Daily'     THEN subscriptions.cost*30.44
-				     ELSE subscriptions.cost END
-				/ CAST(COALESCE(NULLIF(subscriptions.share_count, 0), 1) AS REAL)
-			) as amount,
-			COUNT(*) as count`).
-		Joins("left join categories on subscriptions.category_id = categories.id").
-		Where("subscriptions.status = ?", "Active").
-		Group("categories.name").
-		Scan(&stats).Error; err != nil {
-		return nil, err
-	}
-	return stats, nil
-}

--- a/internal/service/currency.go
+++ b/internal/service/currency.go
@@ -98,6 +98,19 @@ type CurrencyService struct {
 	apiKey string
 }
 
+// Conversion contains a converted amount and the cache state used to calculate it.
+type Conversion struct {
+	Amount   float64
+	RateDate time.Time
+	Stale    bool
+}
+
+type exchangeRateQuote struct {
+	Rate  float64
+	Date  time.Time
+	Stale bool
+}
+
 type FixerResponse struct {
 	Success   bool               `json:"success"`
 	Timestamp int64              `json:"timestamp"`
@@ -126,32 +139,79 @@ func (s *CurrencyService) IsEnabled() bool {
 
 // GetExchangeRate retrieves exchange rate between two currencies
 func (s *CurrencyService) GetExchangeRate(fromCurrency, toCurrency string) (float64, error) {
-	if fromCurrency == toCurrency {
-		return 1.0, nil
-	}
-
-	// Try to get cached rate first
-	rate, err := s.repo.GetRate(fromCurrency, toCurrency)
-	if err == nil && !rate.IsStale() {
-		return rate.Rate, nil
-	}
-
-	// If no API key, return error
-	if !s.IsEnabled() {
-		return 0, fmt.Errorf("currency conversion not available - no Fixer API key configured")
-	}
-
-	// Fetch from Fixer.io API
-	return s.fetchAndCacheRates(fromCurrency, toCurrency)
-}
-
-// ConvertAmount converts an amount from one currency to another
-func (s *CurrencyService) ConvertAmount(amount float64, fromCurrency, toCurrency string) (float64, error) {
-	rate, err := s.GetExchangeRate(fromCurrency, toCurrency)
+	quote, err := s.cachedExchangeRate(fromCurrency, toCurrency)
 	if err != nil {
 		return 0, err
 	}
-	return amount * rate, nil
+	return quote.Rate, nil
+}
+
+// ConvertAmount converts an amount from one currency to another
+func (s *CurrencyService) ConvertAmount(amount float64, fromCurrency, toCurrency string) (Conversion, error) {
+	if fromCurrency == toCurrency {
+		return Conversion{Amount: amount, RateDate: time.Now()}, nil
+	}
+
+	quote, err := s.cachedExchangeRate(fromCurrency, toCurrency)
+	if err != nil {
+		return Conversion{}, err
+	}
+	return Conversion{
+		Amount:   amount * quote.Rate,
+		RateDate: quote.Date,
+		Stale:    quote.Stale,
+	}, nil
+}
+
+func (s *CurrencyService) cachedExchangeRate(fromCurrency, toCurrency string) (*exchangeRateQuote, error) {
+	if fromCurrency == toCurrency {
+		return &exchangeRateQuote{Rate: 1, Date: time.Now()}, nil
+	}
+
+	if fromCurrency == "EUR" {
+		targetRate, err := s.eurRate(toCurrency)
+		if err != nil {
+			return nil, fmt.Errorf("exchange rate for %s to %s not available: %w", fromCurrency, toCurrency, err)
+		}
+		return &exchangeRateQuote{Rate: targetRate.Rate, Date: targetRate.Date, Stale: targetRate.IsStale()}, nil
+	}
+
+	if toCurrency == "EUR" {
+		sourceRate, err := s.eurRate(fromCurrency)
+		if err != nil || sourceRate.Rate == 0 {
+			return nil, fmt.Errorf("exchange rate for %s to %s not available", fromCurrency, toCurrency)
+		}
+		return &exchangeRateQuote{Rate: 1 / sourceRate.Rate, Date: sourceRate.Date, Stale: sourceRate.IsStale()}, nil
+	}
+
+	sourceRate, err := s.eurRate(fromCurrency)
+	if err != nil || sourceRate.Rate == 0 {
+		return nil, fmt.Errorf("exchange rate for %s to %s not available", fromCurrency, toCurrency)
+	}
+	targetRate, err := s.eurRate(toCurrency)
+	if err != nil {
+		return nil, fmt.Errorf("exchange rate for %s to %s not available", fromCurrency, toCurrency)
+	}
+
+	return &exchangeRateQuote{
+		Rate:  targetRate.Rate / sourceRate.Rate,
+		Date:  olderTime(sourceRate.Date, targetRate.Date),
+		Stale: sourceRate.IsStale() || targetRate.IsStale(),
+	}, nil
+}
+
+func (s *CurrencyService) eurRate(currency string) (*models.ExchangeRate, error) {
+	if currency == "EUR" {
+		return &models.ExchangeRate{BaseCurrency: "EUR", Currency: "EUR", Rate: 1, Date: time.Now()}, nil
+	}
+	return s.repo.GetRate("EUR", currency)
+}
+
+func olderTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
 }
 
 // fetchAndCacheRates fetches rates from Fixer.io and caches them.

--- a/internal/service/currency.go
+++ b/internal/service/currency.go
@@ -3,6 +3,7 @@ package service
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,7 +12,15 @@ import (
 	"strings"
 	"subtrackr/internal/models"
 	"subtrackr/internal/repository"
+	"sync"
 	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	fixerURL                      = "https://data.fixer.io/api/latest"
+	currencyRefreshLastAttemptKey = "currency_refresh_last_attempt"
 )
 
 // CurrencyInfo holds metadata for a supported currency
@@ -94,8 +103,13 @@ func supportedCurrencySymbols() string {
 }
 
 type CurrencyService struct {
-	repo   *repository.ExchangeRateRepository
-	apiKey string
+	repo         *repository.ExchangeRateRepository
+	settingsRepo *repository.SettingsRepository
+	apiKey       string
+
+	refreshMu sync.Mutex
+	client    *http.Client
+	endpoint  string
 }
 
 // Conversion contains a converted amount and the cache state used to calculate it.
@@ -125,10 +139,25 @@ type FixerError struct {
 	Info string `json:"info"`
 }
 
-func NewCurrencyService(repo *repository.ExchangeRateRepository) *CurrencyService {
+func NewCurrencyService(repo *repository.ExchangeRateRepository, settingsRepo *repository.SettingsRepository) *CurrencyService {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+	return createCurrencyService(repo, settingsRepo, client, fixerURL, os.Getenv("FIXER_API_KEY"))
+}
+
+func createCurrencyService(repo *repository.ExchangeRateRepository, settingsRepo *repository.SettingsRepository, client *http.Client, endpoint, apiKey string) *CurrencyService {
 	return &CurrencyService{
-		repo:   repo,
-		apiKey: os.Getenv("FIXER_API_KEY"),
+		repo:         repo,
+		settingsRepo: settingsRepo,
+		apiKey:       apiKey,
+		client:       client,
+		endpoint:     endpoint,
 	}
 }
 
@@ -139,7 +168,7 @@ func (s *CurrencyService) IsEnabled() bool {
 
 // GetExchangeRate retrieves exchange rate between two currencies
 func (s *CurrencyService) GetExchangeRate(fromCurrency, toCurrency string) (float64, error) {
-	quote, err := s.cachedExchangeRate(fromCurrency, toCurrency)
+	quote, err := s.exchangeRate(fromCurrency, toCurrency)
 	if err != nil {
 		return 0, err
 	}
@@ -152,7 +181,7 @@ func (s *CurrencyService) ConvertAmount(amount float64, fromCurrency, toCurrency
 		return Conversion{Amount: amount, RateDate: time.Now()}, nil
 	}
 
-	quote, err := s.cachedExchangeRate(fromCurrency, toCurrency)
+	quote, err := s.exchangeRate(fromCurrency, toCurrency)
 	if err != nil {
 		return Conversion{}, err
 	}
@@ -161,6 +190,37 @@ func (s *CurrencyService) ConvertAmount(amount float64, fromCurrency, toCurrency
 		RateDate: quote.Date,
 		Stale:    quote.Stale,
 	}, nil
+}
+
+func (s *CurrencyService) exchangeRate(fromCurrency, toCurrency string) (*exchangeRateQuote, error) {
+	// A complete fresh quote avoids both the Fixer quota and network dependency.
+	quote, cacheErr := s.cachedExchangeRate(fromCurrency, toCurrency)
+	if cacheErr == nil && !quote.Stale {
+		return quote, nil
+	}
+
+	// Stale cached rates remain useful when Fixer is not configured or unavailable.
+	if !s.IsEnabled() {
+		if cacheErr == nil {
+			return quote, nil
+		}
+		return nil, fmt.Errorf("currency conversion not available - no Fixer API key configured: %w", cacheErr)
+	}
+
+	refreshErr := s.refreshRates(false)
+	// Another request may have refreshed the shared snapshot while this one waited.
+	refreshedQuote, refreshedErr := s.cachedExchangeRate(fromCurrency, toCurrency)
+	if refreshedErr == nil {
+		return refreshedQuote, nil
+	}
+	if cacheErr == nil {
+		quote.Stale = true
+		return quote, nil
+	}
+	if refreshErr != nil {
+		return nil, fmt.Errorf("exchange rate for %s to %s not available: %w", fromCurrency, toCurrency, refreshErr)
+	}
+	return nil, refreshedErr
 }
 
 func (s *CurrencyService) cachedExchangeRate(fromCurrency, toCurrency string) (*exchangeRateQuote, error) {
@@ -184,6 +244,8 @@ func (s *CurrencyService) cachedExchangeRate(fromCurrency, toCurrency string) (*
 		return &exchangeRateQuote{Rate: 1 / sourceRate.Rate, Date: sourceRate.Date, Stale: sourceRate.IsStale()}, nil
 	}
 
+	// Free Fixer.io plans provide EUR-based legs, so derive cross-rates as
+	// EUR-to-target divided by EUR-to-source.
 	sourceRate, err := s.eurRate(fromCurrency)
 	if err != nil || sourceRate.Rate == 0 {
 		return nil, fmt.Errorf("exchange rate for %s to %s not available", fromCurrency, toCurrency)
@@ -214,70 +276,68 @@ func olderTime(a, b time.Time) time.Time {
 	return b
 }
 
-// fetchAndCacheRates fetches rates from Fixer.io and caches them.
-// Note: Free Fixer.io plan only supports EUR base, so baseCurrency parameter
-// is used for cross-rate calculations but API always fetches with EUR base.
-func (s *CurrencyService) fetchAndCacheRates(baseCurrency, targetCurrency string) (float64, error) {
-	// Use supported currencies as comma-separated string
-	symbols := supportedCurrencySymbols()
+// fetchAndCacheRates fetches the full EUR-based snapshot from Fixer.io and caches it.
+// Cross-rates are derived from the cached EUR legs so one request serves every pair.
+func (s *CurrencyService) fetchAndCacheRates() error {
+	// Persist before the network call so failed attempts also enforce the cooldown
+	// across requests and application restarts.
+	attemptAt := time.Now().UTC().Format(time.RFC3339Nano)
+	if err := s.settingsRepo.Set(currencyRefreshLastAttemptKey, attemptAt); err != nil {
+		return fmt.Errorf("failed to record exchange-rate refresh attempt: %w", err)
+	}
 
-	// Free Fixer.io plan only supports EUR as base currency
-	// Always fetch with EUR as base and calculate cross-rates if needed
-	apiURL := fmt.Sprintf("https://data.fixer.io/api/latest?access_key=%s&base=EUR&symbols=%s",
-		s.apiKey, symbols)
-
-	// Validate URL to ensure we're calling the expected API
-	parsedURL, err := url.Parse(apiURL)
+	// Free Fixer.io plans only support EUR as the base currency, so always fetch
+	// every supported EUR leg and calculate cross-rates from the cache.
+	parsedURL, err := url.Parse(s.endpoint)
 	if err != nil {
-		return 0, fmt.Errorf("invalid API URL: %w", err)
+		return fmt.Errorf("invalid Fixer endpoint: %w", err)
 	}
-	if parsedURL.Host != "data.fixer.io" {
-		return 0, fmt.Errorf("unauthorized API host: %s", parsedURL.Host)
+	// Validate the production URL to ensure requests only go to the expected API.
+	if s.endpoint == fixerURL && parsedURL.Host != "data.fixer.io" {
+		return fmt.Errorf("unauthorized Fixer host: %s", parsedURL.Host)
 	}
+	query := parsedURL.Query()
+	query.Set("access_key", s.apiKey)
+	query.Set("base", "EUR")
+	query.Set("symbols", supportedCurrencySymbols())
+	parsedURL.RawQuery = query.Encode()
 
-	// Configure HTTP client with security and timeout settings
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS12, // Require TLS 1.2 or higher
-			},
-		},
-	}
-	resp, err := client.Get(apiURL)
+	resp, err := s.client.Get(parsedURL.String())
 	if err != nil {
-		return 0, fmt.Errorf("failed to fetch exchange rates: %w", err)
+		return errors.New("failed to fetch exchange rates")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("Fixer API returned HTTP status %d", resp.StatusCode)
+	}
 
 	var fixerResp FixerResponse
 	if err := json.NewDecoder(resp.Body).Decode(&fixerResp); err != nil {
-		return 0, fmt.Errorf("failed to decode response: %w", err)
+		return fmt.Errorf("failed to decode Fixer response: %w", err)
 	}
 
 	if !fixerResp.Success {
 		if fixerResp.Error != nil {
-			return 0, fmt.Errorf("Fixer API error: %s", fixerResp.Error.Info)
+			return fmt.Errorf("Fixer API error: %s", fixerResp.Error.Info)
 		}
-		return 0, fmt.Errorf("Fixer API request failed")
+		return errors.New("Fixer API request failed")
 	}
 
-	// Parse date
+	// Parse the snapshot date supplied by Fixer rather than the request time.
 	rateDate := time.Unix(fixerResp.Timestamp, 0)
 
-	// Cache all rates (always with EUR as base from Fixer.io)
-	var ratesToSave []models.ExchangeRate
-
-	// Add EUR to EUR rate (1.0)
-	ratesToSave = append(ratesToSave, models.ExchangeRate{
+	// Include the EUR identity rate because Fixer may omit it from the response.
+	ratesToSave := []models.ExchangeRate{{
 		BaseCurrency: "EUR",
 		Currency:     "EUR",
-		Rate:         1.0,
+		Rate:         1,
 		Date:         rateDate,
-	})
+	}}
 
-	// Add all other rates from API
 	for currency, rate := range fixerResp.Rates {
+		if currency == "EUR" {
+			continue
+		}
 		ratesToSave = append(ratesToSave, models.ExchangeRate{
 			BaseCurrency: "EUR",
 			Currency:     currency,
@@ -286,36 +346,55 @@ func (s *CurrencyService) fetchAndCacheRates(baseCurrency, targetCurrency string
 		})
 	}
 
-	if len(ratesToSave) > 0 {
-		if err := s.repo.SaveRates(ratesToSave); err != nil {
-			// Log error but don't fail the request
-			log.Printf("Warning: failed to cache exchange rates: %v", err)
+	// A refresh is only successful when the complete snapshot is persisted;
+	// otherwise later conversions could observe an incomplete currency pair.
+	if err := s.repo.SaveRates(ratesToSave); err != nil {
+		return fmt.Errorf("failed to cache exchange rates: %w", err)
+	}
+
+	return nil
+}
+
+func (s *CurrencyService) refreshAllowed() (bool, error) {
+	lastAttemptValue, err := s.settingsRepo.Get(currencyRefreshLastAttemptKey)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	lastAttemptAt, err := time.Parse(time.RFC3339Nano, lastAttemptValue)
+	if err != nil {
+		return false, fmt.Errorf("invalid currency refresh timestamp: %w", err)
+	}
+	// Use the last attempt, not the last success, so quota and outage failures do
+	// not trigger another Fixer request on every page load.
+	return !time.Now().Before(lastAttemptAt.Add(24 * time.Hour)), nil
+}
+
+func (s *CurrencyService) refreshRates(ignoreCooldown bool) error {
+	// Serialize refreshes within the service; the persisted attempt timestamp then
+	// prevents later service instances from immediately repeating the request.
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
+
+	// Explicit administrative refreshes retain the existing ability to bypass
+	// automatic refresh timing.
+	if !ignoreCooldown {
+		allowed, err := s.refreshAllowed()
+		if err != nil {
+			return fmt.Errorf("failed to read exchange-rate refresh status: %w", err)
+		}
+		if !allowed {
+			return errors.New("currency refresh cooldown is active")
 		}
 	}
 
-	// Calculate the cross-rate if needed
-	if baseCurrency == "EUR" {
-		// Direct rate from EUR
-		if rate, exists := fixerResp.Rates[targetCurrency]; exists {
-			return rate, nil
-		}
-	} else if targetCurrency == "EUR" {
-		// Inverse rate to EUR
-		if rate, exists := fixerResp.Rates[baseCurrency]; exists && rate != 0 {
-			return 1.0 / rate, nil
-		}
-	} else {
-		// Cross-rate: base->EUR->target
-		baseToEur, exists1 := fixerResp.Rates[baseCurrency]
-		eurToTarget, exists2 := fixerResp.Rates[targetCurrency]
-
-		if exists1 && exists2 && baseToEur != 0 {
-			// Convert: (1/baseToEur) * eurToTarget = cross rate
-			return eurToTarget / baseToEur, nil
-		}
+	if err := s.fetchAndCacheRates(); err != nil {
+		log.Printf("Warning: failed to refresh exchange rates: %v", err)
+		return err
 	}
-
-	return 0, fmt.Errorf("exchange rate for %s to %s not available", baseCurrency, targetCurrency)
+	return nil
 }
 
 // RefreshRates updates all exchange rates from the API
@@ -324,10 +403,9 @@ func (s *CurrencyService) RefreshRates() error {
 		return fmt.Errorf("currency service not enabled")
 	}
 
-	// Fetch rates once with EUR base (free Fixer.io plan only supports EUR base)
-	// All cross-rates are calculated from this single API call
-	_, err := s.fetchAndCacheRates("EUR", "USD")
-	if err != nil {
+	// Fetch one full EUR snapshot because the free Fixer.io plan only supports
+	// EUR as its base; all cross-rates are derived from that single response.
+	if err := s.refreshRates(true); err != nil {
 		return fmt.Errorf("failed to refresh rates: %w", err)
 	}
 

--- a/internal/service/currency_integration_test.go
+++ b/internal/service/currency_integration_test.go
@@ -76,7 +76,7 @@ func TestCurrencyService_Integration_ConvertAmount_SameCurrency(t *testing.T) {
 	result, err := service.ConvertAmount(amount, "USD", "USD")
 
 	assert.NoError(t, err)
-	assert.Equal(t, amount, result)
+	assert.Equal(t, amount, result.Amount)
 }
 
 func TestCurrencyService_Integration_ConvertAmount_WithCachedRate(t *testing.T) {
@@ -87,11 +87,11 @@ func TestCurrencyService_Integration_ConvertAmount_WithCachedRate(t *testing.T) 
 	repo := repository.NewExchangeRateRepository(db)
 	service := NewCurrencyService(repo)
 
-	// Create a cached rate
+	// Create a cached EUR-based rate
 	cachedRate := &models.ExchangeRate{
-		BaseCurrency: "USD",
-		Currency:     "EUR",
-		Rate:         0.85,
+		BaseCurrency: "EUR",
+		Currency:     "USD",
+		Rate:         1.25,
 		Date:         time.Now(),
 	}
 
@@ -102,7 +102,7 @@ func TestCurrencyService_Integration_ConvertAmount_WithCachedRate(t *testing.T) 
 	result, err := service.ConvertAmount(amount, "USD", "EUR")
 
 	assert.NoError(t, err)
-	assert.Equal(t, 85.0, result)
+	assert.Equal(t, 80.0, result.Amount)
 }
 
 func TestCurrencyService_Integration_ConvertAmount_NoAPIKey(t *testing.T) {
@@ -116,8 +116,8 @@ func TestCurrencyService_Integration_ConvertAmount_NoAPIKey(t *testing.T) {
 	result, err := service.ConvertAmount(amount, "USD", "EUR")
 
 	assert.Error(t, err)
-	assert.Equal(t, 0.0, result)
-	assert.Contains(t, err.Error(), "currency conversion not available")
+	assert.Equal(t, 0.0, result.Amount)
+	assert.Contains(t, err.Error(), "exchange rate for USD to EUR not available")
 }
 
 func TestCurrencyService_Integration_ConvertAmount_InvalidAmount(t *testing.T) {
@@ -130,9 +130,9 @@ func TestCurrencyService_Integration_ConvertAmount_InvalidAmount(t *testing.T) {
 
 	// Pre-cache a rate to avoid API calls
 	cachedRate := models.ExchangeRate{
-		BaseCurrency: "USD",
-		Currency:     "EUR",
-		Rate:         0.85,
+		BaseCurrency: "EUR",
+		Currency:     "USD",
+		Rate:         1.25,
 		Date:         time.Now(),
 	}
 	repo.SaveRates([]models.ExchangeRate{cachedRate})
@@ -142,7 +142,7 @@ func TestCurrencyService_Integration_ConvertAmount_InvalidAmount(t *testing.T) {
 		amount   float64
 		expected float64
 	}{
-		{"Negative amount", -100.0, -85.0}, // Negative amounts are converted
+		{"Negative amount", -100.0, -80.0}, // Negative amounts are converted
 		{"Zero amount", 0.0, 0.0},
 	}
 
@@ -150,7 +150,7 @@ func TestCurrencyService_Integration_ConvertAmount_InvalidAmount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := service.ConvertAmount(tt.amount, "USD", "EUR")
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, result.Amount)
 		})
 	}
 }
@@ -171,7 +171,7 @@ func TestCurrencyService_Integration_SupportedCurrencies(t *testing.T) {
 			// Test by attempting same-currency conversion (should always work)
 			result, err := service.ConvertAmount(100.0, currency, currency)
 			assert.NoError(t, err)
-			assert.Equal(t, 100.0, result)
+			assert.Equal(t, 100.0, result.Amount)
 		})
 	}
 }
@@ -185,7 +185,7 @@ func TestCurrencyService_Integration_BDTCurrency(t *testing.T) {
 	t.Run("BDT same currency conversion", func(t *testing.T) {
 		result, err := service.ConvertAmount(100.0, "BDT", "BDT")
 		assert.NoError(t, err, "BDT should be supported")
-		assert.Equal(t, 100.0, result, "Same currency conversion should return same amount")
+		assert.Equal(t, 100.0, result.Amount, "Same currency conversion should return same amount")
 	})
 
 	t.Run("BDT in SupportedCurrencies list", func(t *testing.T) {
@@ -287,4 +287,106 @@ func TestSettingsService_SetCurrency_BDT(t *testing.T) {
 			}
 		})
 	}
+}
+
+func saveEURRates(t *testing.T, repo *repository.ExchangeRateRepository, rates ...models.ExchangeRate) {
+	t.Helper()
+	if err := repo.SaveRates(rates); err != nil {
+		t.Fatalf("save EUR rates: %v", err)
+	}
+}
+
+func TestCurrencyService_ConvertAmount_DerivesFreshCrossRateWithoutAPIKey(t *testing.T) {
+	t.Setenv("FIXER_API_KEY", "")
+	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	rateDate := time.Now().Add(-time.Hour)
+	saveEURRates(t, repo,
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: rateDate},
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: rateDate},
+	)
+
+	conversion, err := NewCurrencyService(repo).ConvertAmount(3, "USD", "SEK")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 30.0, conversion.Amount)
+	assert.True(t, conversion.RateDate.Equal(rateDate))
+	assert.False(t, conversion.Stale)
+}
+
+func TestCurrencyService_ConvertAmount_UsesFreshDirectEURRateWithoutAPIKey(t *testing.T) {
+	t.Setenv("FIXER_API_KEY", "")
+	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	rateDate := time.Now().Add(-time.Hour)
+	saveEURRates(t, repo, models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: rateDate})
+
+	conversion, err := NewCurrencyService(repo).ConvertAmount(2, "EUR", "SEK")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 24.0, conversion.Amount)
+	assert.True(t, conversion.RateDate.Equal(rateDate))
+	assert.False(t, conversion.Stale)
+}
+
+func TestCurrencyService_ConvertAmount_UsesFreshInverseEURRateWithoutAPIKey(t *testing.T) {
+	t.Setenv("FIXER_API_KEY", "")
+	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	rateDate := time.Now().Add(-time.Hour)
+	saveEURRates(t, repo, models.ExchangeRate{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: rateDate})
+
+	conversion, err := NewCurrencyService(repo).ConvertAmount(12, "USD", "EUR")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 10.0, conversion.Amount)
+	assert.True(t, conversion.RateDate.Equal(rateDate))
+	assert.False(t, conversion.Stale)
+}
+
+func TestCurrencyService_ConvertAmount_UsesOlderLegAsQuoteDate(t *testing.T) {
+	t.Setenv("FIXER_API_KEY", "")
+	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	newerDate := time.Now().Add(-time.Hour)
+	olderDate := newerDate.Add(-time.Hour)
+	saveEURRates(t, repo,
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: newerDate},
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: olderDate},
+	)
+
+	conversion, err := NewCurrencyService(repo).ConvertAmount(3, "USD", "SEK")
+
+	assert.NoError(t, err)
+	assert.True(t, conversion.RateDate.Equal(olderDate))
+	assert.False(t, conversion.Stale)
+}
+
+func TestCurrencyService_ConvertAmount_ReturnsStaleCachedCrossRateWithoutAPIKey(t *testing.T) {
+	t.Setenv("FIXER_API_KEY", "")
+	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	rateDate := time.Now().Add(-5 * 24 * time.Hour)
+	saveEURRates(t, repo,
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: rateDate},
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: rateDate},
+	)
+
+	conversion, err := NewCurrencyService(repo).ConvertAmount(3, "USD", "SEK")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 30.0, conversion.Amount)
+	assert.True(t, conversion.RateDate.Equal(rateDate))
+	assert.True(t, conversion.Stale)
+}
+
+func TestCurrencyService_ConvertAmount_FailsWithoutCompleteCachedPairOrAPIKey(t *testing.T) {
+	t.Setenv("FIXER_API_KEY", "")
+	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	saveEURRates(t, repo, models.ExchangeRate{
+		BaseCurrency: "EUR",
+		Currency:     "USD",
+		Rate:         1.2,
+		Date:         time.Now().Add(-time.Hour),
+	})
+
+	conversion, err := NewCurrencyService(repo).ConvertAmount(3, "USD", "SEK")
+
+	assert.Error(t, err)
+	assert.Zero(t, conversion.Amount)
 }

--- a/internal/service/currency_integration_test.go
+++ b/internal/service/currency_integration_test.go
@@ -1,25 +1,37 @@
 package service
 
 import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"subtrackr/internal/models"
 	"subtrackr/internal/repository"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func setupTestDB(t *testing.T) *gorm.DB {
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "currency.db")), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
 	if err != nil {
 		t.Fatalf("Failed to open test database: %v", err)
 	}
 
 	// Migrate the schema
-	err = db.AutoMigrate(&models.ExchangeRate{})
+	err = db.AutoMigrate(&models.ExchangeRate{}, &models.Settings{})
 	if err != nil {
 		t.Fatalf("Failed to migrate test database: %v", err)
 	}
@@ -57,7 +69,7 @@ func TestCurrencyService_Integration_IsEnabled(t *testing.T) {
 				os.Unsetenv("FIXER_API_KEY")
 			}
 
-			service := NewCurrencyService(repo)
+			service := NewCurrencyService(repo, repository.NewSettingsRepository(db))
 			assert.Equal(t, tt.expected, service.IsEnabled())
 		})
 	}
@@ -69,7 +81,7 @@ func TestCurrencyService_Integration_IsEnabled(t *testing.T) {
 func TestCurrencyService_Integration_ConvertAmount_SameCurrency(t *testing.T) {
 	db := setupTestDB(t)
 	repo := repository.NewExchangeRateRepository(db)
-	service := NewCurrencyService(repo)
+	service := NewCurrencyService(repo, repository.NewSettingsRepository(db))
 
 	// Test same currency conversion (should return same amount)
 	amount := 100.0
@@ -85,7 +97,7 @@ func TestCurrencyService_Integration_ConvertAmount_WithCachedRate(t *testing.T) 
 
 	db := setupTestDB(t)
 	repo := repository.NewExchangeRateRepository(db)
-	service := NewCurrencyService(repo)
+	service := NewCurrencyService(repo, repository.NewSettingsRepository(db))
 
 	// Create a cached EUR-based rate
 	cachedRate := &models.ExchangeRate{
@@ -110,7 +122,7 @@ func TestCurrencyService_Integration_ConvertAmount_NoAPIKey(t *testing.T) {
 
 	db := setupTestDB(t)
 	repo := repository.NewExchangeRateRepository(db)
-	service := NewCurrencyService(repo)
+	service := NewCurrencyService(repo, repository.NewSettingsRepository(db))
 
 	amount := 100.0
 	result, err := service.ConvertAmount(amount, "USD", "EUR")
@@ -126,7 +138,7 @@ func TestCurrencyService_Integration_ConvertAmount_InvalidAmount(t *testing.T) {
 
 	db := setupTestDB(t)
 	repo := repository.NewExchangeRateRepository(db)
-	service := NewCurrencyService(repo)
+	service := NewCurrencyService(repo, repository.NewSettingsRepository(db))
 
 	// Pre-cache a rate to avoid API calls
 	cachedRate := models.ExchangeRate{
@@ -158,7 +170,7 @@ func TestCurrencyService_Integration_ConvertAmount_InvalidAmount(t *testing.T) {
 func TestCurrencyService_Integration_SupportedCurrencies(t *testing.T) {
 	db := setupTestDB(t)
 	repo := repository.NewExchangeRateRepository(db)
-	service := NewCurrencyService(repo)
+	service := NewCurrencyService(repo, repository.NewSettingsRepository(db))
 
 	// Test that common currencies are supported
 	supportedCurrencies := []string{
@@ -179,7 +191,7 @@ func TestCurrencyService_Integration_SupportedCurrencies(t *testing.T) {
 func TestCurrencyService_Integration_BDTCurrency(t *testing.T) {
 	db := setupTestDB(t)
 	repo := repository.NewExchangeRateRepository(db)
-	service := NewCurrencyService(repo)
+	service := NewCurrencyService(repo, repository.NewSettingsRepository(db))
 
 	// Test BDT currency support
 	t.Run("BDT same currency conversion", func(t *testing.T) {
@@ -298,14 +310,15 @@ func saveEURRates(t *testing.T, repo *repository.ExchangeRateRepository, rates .
 
 func TestCurrencyService_ConvertAmount_DerivesFreshCrossRateWithoutAPIKey(t *testing.T) {
 	t.Setenv("FIXER_API_KEY", "")
-	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
 	rateDate := time.Now().Add(-time.Hour)
 	saveEURRates(t, repo,
 		models.ExchangeRate{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: rateDate},
 		models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: rateDate},
 	)
 
-	conversion, err := NewCurrencyService(repo).ConvertAmount(3, "USD", "SEK")
+	conversion, err := NewCurrencyService(repo, repository.NewSettingsRepository(db)).ConvertAmount(3, "USD", "SEK")
 
 	assert.NoError(t, err)
 	assert.Equal(t, 30.0, conversion.Amount)
@@ -315,11 +328,12 @@ func TestCurrencyService_ConvertAmount_DerivesFreshCrossRateWithoutAPIKey(t *tes
 
 func TestCurrencyService_ConvertAmount_UsesFreshDirectEURRateWithoutAPIKey(t *testing.T) {
 	t.Setenv("FIXER_API_KEY", "")
-	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
 	rateDate := time.Now().Add(-time.Hour)
 	saveEURRates(t, repo, models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: rateDate})
 
-	conversion, err := NewCurrencyService(repo).ConvertAmount(2, "EUR", "SEK")
+	conversion, err := NewCurrencyService(repo, repository.NewSettingsRepository(db)).ConvertAmount(2, "EUR", "SEK")
 
 	assert.NoError(t, err)
 	assert.Equal(t, 24.0, conversion.Amount)
@@ -329,11 +343,12 @@ func TestCurrencyService_ConvertAmount_UsesFreshDirectEURRateWithoutAPIKey(t *te
 
 func TestCurrencyService_ConvertAmount_UsesFreshInverseEURRateWithoutAPIKey(t *testing.T) {
 	t.Setenv("FIXER_API_KEY", "")
-	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
 	rateDate := time.Now().Add(-time.Hour)
 	saveEURRates(t, repo, models.ExchangeRate{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: rateDate})
 
-	conversion, err := NewCurrencyService(repo).ConvertAmount(12, "USD", "EUR")
+	conversion, err := NewCurrencyService(repo, repository.NewSettingsRepository(db)).ConvertAmount(12, "USD", "EUR")
 
 	assert.NoError(t, err)
 	assert.Equal(t, 10.0, conversion.Amount)
@@ -343,7 +358,8 @@ func TestCurrencyService_ConvertAmount_UsesFreshInverseEURRateWithoutAPIKey(t *t
 
 func TestCurrencyService_ConvertAmount_UsesOlderLegAsQuoteDate(t *testing.T) {
 	t.Setenv("FIXER_API_KEY", "")
-	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
 	newerDate := time.Now().Add(-time.Hour)
 	olderDate := newerDate.Add(-time.Hour)
 	saveEURRates(t, repo,
@@ -351,7 +367,7 @@ func TestCurrencyService_ConvertAmount_UsesOlderLegAsQuoteDate(t *testing.T) {
 		models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: olderDate},
 	)
 
-	conversion, err := NewCurrencyService(repo).ConvertAmount(3, "USD", "SEK")
+	conversion, err := NewCurrencyService(repo, repository.NewSettingsRepository(db)).ConvertAmount(3, "USD", "SEK")
 
 	assert.NoError(t, err)
 	assert.True(t, conversion.RateDate.Equal(olderDate))
@@ -360,14 +376,15 @@ func TestCurrencyService_ConvertAmount_UsesOlderLegAsQuoteDate(t *testing.T) {
 
 func TestCurrencyService_ConvertAmount_ReturnsStaleCachedCrossRateWithoutAPIKey(t *testing.T) {
 	t.Setenv("FIXER_API_KEY", "")
-	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
 	rateDate := time.Now().Add(-5 * 24 * time.Hour)
 	saveEURRates(t, repo,
 		models.ExchangeRate{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: rateDate},
 		models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: rateDate},
 	)
 
-	conversion, err := NewCurrencyService(repo).ConvertAmount(3, "USD", "SEK")
+	conversion, err := NewCurrencyService(repo, repository.NewSettingsRepository(db)).ConvertAmount(3, "USD", "SEK")
 
 	assert.NoError(t, err)
 	assert.Equal(t, 30.0, conversion.Amount)
@@ -377,7 +394,8 @@ func TestCurrencyService_ConvertAmount_ReturnsStaleCachedCrossRateWithoutAPIKey(
 
 func TestCurrencyService_ConvertAmount_FailsWithoutCompleteCachedPairOrAPIKey(t *testing.T) {
 	t.Setenv("FIXER_API_KEY", "")
-	repo := repository.NewExchangeRateRepository(setupTestDB(t))
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
 	saveEURRates(t, repo, models.ExchangeRate{
 		BaseCurrency: "EUR",
 		Currency:     "USD",
@@ -385,8 +403,186 @@ func TestCurrencyService_ConvertAmount_FailsWithoutCompleteCachedPairOrAPIKey(t 
 		Date:         time.Now().Add(-time.Hour),
 	})
 
-	conversion, err := NewCurrencyService(repo).ConvertAmount(3, "USD", "SEK")
+	conversion, err := NewCurrencyService(repo, repository.NewSettingsRepository(db)).ConvertAmount(3, "USD", "SEK")
 
 	assert.Error(t, err)
 	assert.Zero(t, conversion.Amount)
+}
+
+func fixerSuccessBody(at time.Time) string {
+	return fmt.Sprintf(`{"success":true,"timestamp":%d,"base":"EUR","date":"%s","rates":{"USD":1.2,"SEK":12,"GBP":0.8}}`, at.Unix(), at.Format("2006-01-02"))
+}
+
+func newFixerTestServer(t *testing.T, body string, requestCount *atomic.Int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		if r.URL.Query().Get("access_key") != "test-key" {
+			t.Errorf("access_key = %q, want test-key", r.URL.Query().Get("access_key"))
+		}
+		if r.URL.Query().Get("base") != "EUR" {
+			t.Errorf("base = %q, want EUR", r.URL.Query().Get("base"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("write Fixer response: %v", err)
+		}
+	}))
+}
+
+func newTestCurrencyService(repo *repository.ExchangeRateRepository, settingsRepo *repository.SettingsRepository, server *httptest.Server) *CurrencyService {
+	return createCurrencyService(repo, settingsRepo, server.Client(), server.URL, "test-key")
+}
+
+func captureCurrencyLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var logs bytes.Buffer
+	previousWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previousWriter) })
+	return &logs
+}
+
+func TestCurrencyService_RefreshesAllRatesOnceForConcurrentConversions(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	now := time.Now().UTC().Truncate(time.Second)
+	staleDate := now.Add(-5 * 24 * time.Hour)
+	saveEURRates(t, repo,
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "USD", Rate: 1.1, Date: staleDate},
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 11, Date: staleDate},
+	)
+	var requestCount atomic.Int32
+	server := newFixerTestServer(t, fixerSuccessBody(now), &requestCount)
+	defer server.Close()
+	currencyService := newTestCurrencyService(repo, settingsRepo, server)
+
+	const conversionCount = 20
+	results := make(chan Conversion, conversionCount)
+	errors := make(chan error, conversionCount)
+	var conversions sync.WaitGroup
+	for range conversionCount {
+		conversions.Add(1)
+		go func() {
+			defer conversions.Done()
+			conversion, err := currencyService.ConvertAmount(3, "USD", "SEK")
+			results <- conversion
+			errors <- err
+		}()
+	}
+	conversions.Wait()
+	close(results)
+	close(errors)
+
+	for err := range errors {
+		assert.NoError(t, err)
+	}
+	for conversion := range results {
+		assert.Equal(t, 30.0, conversion.Amount)
+		assert.False(t, conversion.Stale)
+	}
+	assert.Equal(t, int32(1), requestCount.Load())
+}
+
+func TestCurrencyService_ReusesFreshSnapshotForDifferentCurrencyPair(t *testing.T) {
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	now := time.Now().UTC().Truncate(time.Second)
+	var requestCount atomic.Int32
+	server := newFixerTestServer(t, fixerSuccessBody(now), &requestCount)
+	defer server.Close()
+	currencyService := newTestCurrencyService(repo, settingsRepo, server)
+
+	sekConversion, err := currencyService.ConvertAmount(3, "USD", "SEK")
+	assert.NoError(t, err)
+	assert.Equal(t, 30.0, sekConversion.Amount)
+
+	usdConversion, err := currencyService.ConvertAmount(8, "GBP", "USD")
+	assert.NoError(t, err)
+	assert.InDelta(t, 12.0, usdConversion.Amount, 0.000001)
+	assert.Equal(t, int32(1), requestCount.Load())
+}
+
+func TestCurrencyService_UsesStaleRatesWhenFixerReturnsQuotaError(t *testing.T) {
+	logs := captureCurrencyLogs(t)
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	staleDate := time.Now().Add(-5 * 24 * time.Hour)
+	saveEURRates(t, repo,
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: staleDate},
+		models.ExchangeRate{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: staleDate},
+	)
+	var requestCount atomic.Int32
+	server := newFixerTestServer(t, `{"success":false,"error":{"code":104,"info":"monthly quota reached"}}`, &requestCount)
+	defer server.Close()
+
+	conversion, err := newTestCurrencyService(repo, settingsRepo, server).ConvertAmount(3, "USD", "SEK")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 30.0, conversion.Amount)
+	assert.True(t, conversion.Stale)
+	assert.True(t, conversion.RateDate.Equal(staleDate))
+	assert.Equal(t, int32(1), requestCount.Load())
+	assert.Contains(t, logs.String(), "monthly quota reached")
+}
+
+func TestCurrencyService_DoesNotRetryFailedRefreshDuringCooldown(t *testing.T) {
+	logs := captureCurrencyLogs(t)
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	var requestCount atomic.Int32
+	server := newFixerTestServer(t, `{"success":false,"error":{"code":104,"info":"monthly quota reached"}}`, &requestCount)
+	defer server.Close()
+
+	_, firstError := newTestCurrencyService(repo, settingsRepo, server).ConvertAmount(3, "USD", "SEK")
+	_, secondError := newTestCurrencyService(repo, settingsRepo, server).ConvertAmount(3, "USD", "SEK")
+
+	assert.Error(t, firstError)
+	assert.Error(t, secondError)
+	assert.Equal(t, int32(1), requestCount.Load())
+	assert.Equal(t, 1, bytes.Count(logs.Bytes(), []byte("monthly quota reached")))
+}
+
+func TestCurrencyService_RetriesAfterCooldown(t *testing.T) {
+	logs := captureCurrencyLogs(t)
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	var requestCount atomic.Int32
+	server := newFixerTestServer(t, `{"success":false,"error":{"code":104,"info":"monthly quota reached"}}`, &requestCount)
+	defer server.Close()
+	currencyService := newTestCurrencyService(repo, settingsRepo, server)
+
+	_, firstError := currencyService.ConvertAmount(3, "USD", "SEK")
+	oldAttempt := time.Now().Add(-25 * time.Hour).UTC().Format(time.RFC3339Nano)
+	if err := settingsRepo.Set(currencyRefreshLastAttemptKey, oldAttempt); err != nil {
+		t.Fatalf("age failed refresh status: %v", err)
+	}
+	_, secondError := currencyService.ConvertAmount(3, "USD", "SEK")
+
+	assert.Error(t, firstError)
+	assert.Error(t, secondError)
+	assert.Equal(t, int32(2), requestCount.Load())
+	assert.Equal(t, 2, bytes.Count(logs.Bytes(), []byte("monthly quota reached")))
+}
+
+func TestCurrencyService_ReturnsErrorWhenRefreshFailsWithoutCachedPair(t *testing.T) {
+	logs := captureCurrencyLogs(t)
+	db := setupTestDB(t)
+	repo := repository.NewExchangeRateRepository(db)
+	settingsRepo := repository.NewSettingsRepository(db)
+	var requestCount atomic.Int32
+	server := newFixerTestServer(t, `{"success":false,"error":{"code":104,"info":"monthly quota reached"}}`, &requestCount)
+	defer server.Close()
+
+	conversion, err := newTestCurrencyService(repo, settingsRepo, server).ConvertAmount(3, "USD", "SEK")
+
+	assert.Error(t, err)
+	assert.Zero(t, conversion.Amount)
+	assert.Equal(t, int32(1), requestCount.Load())
+	assert.Contains(t, logs.String(), "monthly quota reached")
 }

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -108,7 +108,7 @@ func (s *SubscriptionService) Count() int64 {
 	return s.repo.Count()
 }
 
-func (s *SubscriptionService) GetStats() (*models.Stats, error) {
+func (s *SubscriptionService) GetStats(currencyService *CurrencyService, displayCurrency string) (*models.Stats, error) {
 	activeSubscriptions, err := s.repo.GetActiveSubscriptions()
 	if err != nil {
 		return nil, err
@@ -124,36 +124,87 @@ func (s *SubscriptionService) GetStats() (*models.Stats, error) {
 		return nil, err
 	}
 
-	categoryStats, err := s.repo.GetCategoryStats()
-	if err != nil {
-		return nil, err
-	}
-
 	stats := &models.Stats{
-		ActiveSubscriptions:    len(activeSubscriptions),
-		CancelledSubscriptions: len(cancelledSubscriptions),
-		UpcomingRenewals:       len(upcomingRenewals),
-		CategorySpending:       make(map[string]float64),
+		ActiveSubscriptions:        len(activeSubscriptions),
+		CancelledSubscriptions:     len(cancelledSubscriptions),
+		UpcomingRenewals:           len(upcomingRenewals),
+		CategorySpending:           make(map[string]float64),
+		ConversionComplete:         true,
+		TotalsByCurrency:           make(map[string]models.CurrencyTotals),
+		CategorySpendingByCurrency: make(map[string]map[string]float64),
 	}
 
-	// Calculate totals
-	for _, sub := range activeSubscriptions {
-		stats.TotalMonthlySpend += sub.MonthlyCost()
-		stats.TotalAnnualSpend += sub.AnnualCost()
+	currencies := make(map[string]struct{})
+	for i := range activeSubscriptions {
+		sub := &activeSubscriptions[i]
+		currency := subscriptionCurrency(sub, displayCurrency)
+		currencies[currency] = struct{}{}
+		addActiveCurrencyTotals(stats, currency, sub)
+	}
+	for i := range cancelledSubscriptions {
+		sub := &cancelledSubscriptions[i]
+		currency := subscriptionCurrency(sub, displayCurrency)
+		currencies[currency] = struct{}{}
+		addCancelledCurrencyTotals(stats, currency, sub)
 	}
 
-	// Calculate savings from cancelled subscriptions
-	for _, sub := range cancelledSubscriptions {
-		stats.TotalSaved += sub.AnnualCost()
-		stats.MonthlySaved += sub.MonthlyCost()
+	rates := make(map[string]float64, len(currencies))
+	for currency := range currencies {
+		rate, err := currencyService.GetExchangeRate(currency, displayCurrency)
+		if err != nil {
+			stats.ConversionComplete = false
+			break
+		}
+		rates[currency] = rate
 	}
 
-	// Build category spending map
-	for _, cat := range categoryStats {
-		stats.CategorySpending[cat.Category] = cat.Amount
+	if !stats.ConversionComplete {
+		return stats, nil
+	}
+
+	for i := range activeSubscriptions {
+		sub := &activeSubscriptions[i]
+		rate := rates[subscriptionCurrency(sub, displayCurrency)]
+		stats.TotalMonthlySpend += sub.MonthlyCost() * rate
+		stats.TotalAnnualSpend += sub.AnnualCost() * rate
+		stats.CategorySpending[sub.Category.Name] += sub.MonthlyCost() * rate
+	}
+	for i := range cancelledSubscriptions {
+		sub := &cancelledSubscriptions[i]
+		rate := rates[subscriptionCurrency(sub, displayCurrency)]
+		stats.TotalSaved += sub.AnnualCost() * rate
+		stats.MonthlySaved += sub.MonthlyCost() * rate
 	}
 
 	return stats, nil
+}
+
+func subscriptionCurrency(subscription *models.Subscription, displayCurrency string) string {
+	if subscription.OriginalCurrency == "" {
+		return displayCurrency
+	}
+	return subscription.OriginalCurrency
+}
+
+func addActiveCurrencyTotals(stats *models.Stats, currency string, subscription *models.Subscription) {
+	totals := stats.TotalsByCurrency[currency]
+	totals.TotalMonthlySpend += subscription.MonthlyCost()
+	totals.TotalAnnualSpend += subscription.AnnualCost()
+	totals.ActiveSubscriptions++
+	stats.TotalsByCurrency[currency] = totals
+
+	if stats.CategorySpendingByCurrency[subscription.Category.Name] == nil {
+		stats.CategorySpendingByCurrency[subscription.Category.Name] = make(map[string]float64)
+	}
+	stats.CategorySpendingByCurrency[subscription.Category.Name][currency] += subscription.MonthlyCost()
+}
+
+func addCancelledCurrencyTotals(stats *models.Stats, currency string, subscription *models.Subscription) {
+	totals := stats.TotalsByCurrency[currency]
+	totals.TotalSaved += subscription.AnnualCost()
+	totals.MonthlySaved += subscription.MonthlyCost()
+	totals.CancelledSubscriptions++
+	stats.TotalsByCurrency[currency] = totals
 }
 
 func (s *SubscriptionService) GetAllCategories() ([]models.Category, error) {

--- a/internal/service/subscription_stats_test.go
+++ b/internal/service/subscription_stats_test.go
@@ -1,0 +1,169 @@
+package service
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"subtrackr/internal/models"
+	"subtrackr/internal/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+type statsTestServices struct {
+	subscriptions *SubscriptionService
+	currency      *CurrencyService
+	rates         *repository.ExchangeRateRepository
+	categories    *CategoryService
+}
+
+func newStatsTestServices(t *testing.T) statsTestServices {
+	t.Helper()
+	t.Setenv("FIXER_API_KEY", "")
+
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "stats.db")), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&models.Category{},
+		&models.Tag{},
+		&models.Subscription{},
+		&models.ExchangeRate{},
+		&models.Settings{},
+	))
+
+	categoryService := NewCategoryService(repository.NewCategoryRepository(db))
+	settingsRepo := repository.NewSettingsRepository(db)
+	rateRepo := repository.NewExchangeRateRepository(db)
+
+	return statsTestServices{
+		subscriptions: NewSubscriptionService(repository.NewSubscriptionRepository(db), categoryService),
+		currency:      NewCurrencyService(rateRepo, settingsRepo),
+		rates:         rateRepo,
+		categories:    categoryService,
+	}
+}
+
+func createStatsCategory(t *testing.T, services statsTestServices, name string) *models.Category {
+	t.Helper()
+	category, err := services.categories.Create(&models.Category{Name: name})
+	require.NoError(t, err)
+	return category
+}
+
+func createStatsSubscription(t *testing.T, services statsTestServices, subscription models.Subscription) {
+	t.Helper()
+	_, err := services.subscriptions.Create(&subscription)
+	require.NoError(t, err)
+}
+
+func seedUSDToSEKRate(t *testing.T, services statsTestServices) {
+	t.Helper()
+	rateDate := time.Now().Add(-time.Hour)
+	require.NoError(t, services.rates.SaveRates([]models.ExchangeRate{
+		{BaseCurrency: "EUR", Currency: "USD", Rate: 1.2, Date: rateDate},
+		{BaseCurrency: "EUR", Currency: "SEK", Rate: 12, Date: rateDate},
+	}))
+}
+
+func seedMixedCurrencyStats(t *testing.T, services statsTestServices) {
+	t.Helper()
+	localCategory := createStatsCategory(t, services, "Local")
+	foreignCategory := createStatsCategory(t, services, "Foreign")
+
+	createStatsSubscription(t, services, models.Subscription{
+		Name:             "Local active",
+		Cost:             20,
+		OriginalCurrency: "SEK",
+		Schedule:         "Monthly",
+		Status:           "Active",
+		CategoryID:       localCategory.ID,
+	})
+	createStatsSubscription(t, services, models.Subscription{
+		Name:             "Foreign active",
+		Cost:             3,
+		OriginalCurrency: "USD",
+		Schedule:         "Monthly",
+		Status:           "Active",
+		CategoryID:       foreignCategory.ID,
+	})
+	createStatsSubscription(t, services, models.Subscription{
+		Name:             "Foreign cancelled",
+		Cost:             120,
+		OriginalCurrency: "USD",
+		Schedule:         "Annual",
+		Status:           "Cancelled",
+		CategoryID:       foreignCategory.ID,
+	})
+}
+
+func TestSubscriptionService_GetStats_ConvertsEveryAggregateWhenRatesExist(t *testing.T) {
+	services := newStatsTestServices(t)
+	seedMixedCurrencyStats(t, services)
+	seedUSDToSEKRate(t, services)
+
+	stats, err := services.subscriptions.GetStats(services.currency, "SEK")
+
+	require.NoError(t, err)
+	assert.True(t, stats.ConversionComplete)
+	assert.InDelta(t, 50, stats.TotalMonthlySpend, 0.001)
+	assert.InDelta(t, 600, stats.TotalAnnualSpend, 0.001)
+	assert.InDelta(t, 100, stats.MonthlySaved, 0.001)
+	assert.InDelta(t, 1200, stats.TotalSaved, 0.001)
+	assert.InDelta(t, 20, stats.CategorySpending["Local"], 0.001)
+	assert.InDelta(t, 30, stats.CategorySpending["Foreign"], 0.001)
+	assert.Equal(t, 2, stats.ActiveSubscriptions)
+	assert.Equal(t, 1, stats.CancelledSubscriptions)
+}
+
+func TestSubscriptionService_GetStats_GroupsEveryAggregateWhenARateIsMissing(t *testing.T) {
+	services := newStatsTestServices(t)
+	seedMixedCurrencyStats(t, services)
+
+	stats, err := services.subscriptions.GetStats(services.currency, "SEK")
+
+	require.NoError(t, err)
+	assert.False(t, stats.ConversionComplete)
+	assert.Zero(t, stats.TotalMonthlySpend)
+	assert.Zero(t, stats.TotalAnnualSpend)
+	assert.Zero(t, stats.MonthlySaved)
+	assert.Zero(t, stats.TotalSaved)
+	assert.Empty(t, stats.CategorySpending)
+
+	assert.InDelta(t, 20, stats.TotalsByCurrency["SEK"].TotalMonthlySpend, 0.001)
+	assert.InDelta(t, 240, stats.TotalsByCurrency["SEK"].TotalAnnualSpend, 0.001)
+	assert.InDelta(t, 3, stats.TotalsByCurrency["USD"].TotalMonthlySpend, 0.001)
+	assert.InDelta(t, 36, stats.TotalsByCurrency["USD"].TotalAnnualSpend, 0.001)
+	assert.InDelta(t, 10, stats.TotalsByCurrency["USD"].MonthlySaved, 0.001)
+	assert.InDelta(t, 120, stats.TotalsByCurrency["USD"].TotalSaved, 0.001)
+	assert.InDelta(t, 20, stats.CategorySpendingByCurrency["Local"]["SEK"], 0.001)
+	assert.InDelta(t, 3, stats.CategorySpendingByCurrency["Foreign"]["USD"], 0.001)
+}
+
+func TestSubscriptionService_GetStats_UsesScheduleIntervalForCategorySpending(t *testing.T) {
+	services := newStatsTestServices(t)
+	category := createStatsCategory(t, services, "Every other month")
+	createStatsSubscription(t, services, models.Subscription{
+		Name:             "Interval subscription",
+		Cost:             20,
+		OriginalCurrency: "SEK",
+		Schedule:         "Monthly",
+		ScheduleInterval: 2,
+		Status:           "Active",
+		CategoryID:       category.ID,
+	})
+
+	stats, err := services.subscriptions.GetStats(services.currency, "SEK")
+
+	require.NoError(t, err)
+	assert.True(t, stats.ConversionComplete)
+	assert.InDelta(t, 10, stats.TotalMonthlySpend, 0.001)
+	assert.InDelta(t, 120, stats.TotalAnnualSpend, 0.001)
+	assert.InDelta(t, 10, stats.CategorySpending["Every other month"], 0.001)
+}

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -173,19 +173,39 @@
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
     <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700 transition-colors duration-200">
         <h3 class="text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">{{t .Lang "analytics.total_monthly_spend"}}</h3>
+        {{if .Stats.ConversionComplete}}
         <p class="text-2xl font-bold text-primary">{{.CurrencySymbol}}{{printf "%.2f" .Stats.TotalMonthlySpend}}</p>
+        {{else}}
+        {{range $currency, $totals := .Stats.TotalsByCurrency}}{{if $totals.ActiveSubscriptions}}
+        <p class="text-2xl font-bold text-primary">{{printf "%.2f" $totals.TotalMonthlySpend}} {{$currency}}</p>
+        {{end}}{{end}}
+        {{end}}
         <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Across {{.Stats.ActiveSubscriptions}} active subscriptions</p>
     </div>
     
     <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700 transition-colors duration-200">
         <h3 class="text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">{{t .Lang "analytics.total_annual_spend"}}</h3>
+        {{if .Stats.ConversionComplete}}
         <p class="text-2xl font-bold text-success">{{.CurrencySymbol}}{{printf "%.2f" .Stats.TotalAnnualSpend}}</p>
+        {{else}}
+        {{range $currency, $totals := .Stats.TotalsByCurrency}}{{if $totals.ActiveSubscriptions}}
+        <p class="text-2xl font-bold text-success">{{printf "%.2f" $totals.TotalAnnualSpend}} {{$currency}}</p>
+        {{end}}{{end}}
+        {{end}}
         <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{t .Lang "analytics.projected_yearly"}}</p>
     </div>
     
     <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700 transition-colors duration-200">
         <h3 class="text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">{{t .Lang "analytics.annual_savings"}}</h3>
+        {{if .Stats.ConversionComplete}}
         <p class="text-2xl font-bold text-danger">{{.CurrencySymbol}}{{printf "%.2f" .Stats.TotalSaved}}</p>
+        {{else if .Stats.CancelledSubscriptions}}
+        {{range $currency, $totals := .Stats.TotalsByCurrency}}{{if $totals.CancelledSubscriptions}}
+        <p class="text-2xl font-bold text-danger">{{printf "%.2f" $totals.TotalSaved}} {{$currency}}</p>
+        {{end}}{{end}}
+        {{else}}
+        <p class="text-2xl font-bold text-danger">{{.CurrencySymbol}}0.00</p>
+        {{end}}
         <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">From {{.Stats.CancelledSubscriptions}} cancelled subscriptions</p>
     </div>
 </div>
@@ -196,6 +216,7 @@
     <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-sm border border-gray-200 dark:border-gray-700 transition-colors duration-200">
         <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-6">{{t .Lang "analytics.spending_by_category"}}</h3>
         <div class="space-y-4">
+            {{if .Stats.ConversionComplete}}
             {{range $category, $amount := .Stats.CategorySpending}}
             <div class="flex items-center justify-between">
                 <div class="flex items-center flex-1">
@@ -210,6 +231,21 @@
                     <span class="text-sm font-medium text-gray-900 dark:text-white w-16 text-right">{{$.CurrencySymbol}}{{printf "%.2f" $amount}}</span>
                 </div>
             </div>
+            {{end}}
+            {{else}}
+            {{range $category, $amounts := .Stats.CategorySpendingByCurrency}}
+            <div class="flex items-center justify-between">
+                <div class="flex items-center">
+                    <div class="w-3 h-3 bg-primary rounded-full mr-3"></div>
+                    <span class="text-sm font-medium text-gray-700 dark:text-gray-200">{{$category}}</span>
+                </div>
+                <div class="text-right">
+                    {{range $currency, $amount := $amounts}}
+                    <div class="text-sm font-medium text-gray-900 dark:text-white">{{printf "%.2f" $amount}} {{$currency}}</div>
+                    {{end}}
+                </div>
+            </div>
+            {{end}}
             {{end}}
         </div>
     </div>
@@ -250,12 +286,24 @@
     <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-6">{{t .Lang "analytics.cost_analysis"}}</h3>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div class="text-center p-4 bg-blue-50 dark:bg-blue-900/50 rounded-lg transition-colors duration-200">
+            {{if .Stats.ConversionComplete}}
             <p class="text-2xl font-bold text-primary">{{.CurrencySymbol}}{{printf "%.2f" (div .Stats.TotalMonthlySpend 30)}}</p>
+            {{else}}
+            {{range $currency, $totals := .Stats.TotalsByCurrency}}{{if $totals.ActiveSubscriptions}}
+            <p class="text-2xl font-bold text-primary">{{printf "%.2f" (div $totals.TotalMonthlySpend 30)}} {{$currency}}</p>
+            {{end}}{{end}}
+            {{end}}
             <p class="text-sm text-gray-600 dark:text-gray-300">{{t .Lang "analytics.avg_daily_cost"}}</p>
         </div>
         
         <div class="text-center p-4 bg-green-50 dark:bg-green-900/50 rounded-lg transition-colors duration-200">
+            {{if .Stats.ConversionComplete}}
             <p class="text-2xl font-bold text-success">{{.CurrencySymbol}}{{printf "%.2f" .Stats.TotalMonthlySpend}}</p>
+            {{else}}
+            {{range $currency, $totals := .Stats.TotalsByCurrency}}{{if $totals.ActiveSubscriptions}}
+            <p class="text-2xl font-bold text-success">{{printf "%.2f" $totals.TotalMonthlySpend}} {{$currency}}</p>
+            {{end}}{{end}}
+            {{end}}
             <p class="text-sm text-gray-600 dark:text-gray-300">{{t .Lang "analytics.total_monthly_cost"}}</p>
         </div>
     </div>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -267,8 +267,6 @@
         
         const year = parseInt({{.Year}}) || new Date().getFullYear();
         const month = parseInt({{.Month}}) || new Date().getMonth() + 1;
-        const currencySymbol = "{{.CurrencySymbol}}";
-        
         console.log('Calendar initialized:', { year, month, eventsCount: Object.keys(eventsByDate).length });
         
         // Render calendar grid
@@ -312,6 +310,7 @@
                         const eventName = (event.name || '').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
                         const eventId = event.id || 0;
                         const iconURL = event.icon_url || '';
+                        const currencySymbol = event.currency_symbol || '';
                         const hasIcon = iconURL && iconURL.trim() !== '';
                         
                         let iconHtml = '';

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -175,7 +175,13 @@
         <div class="flex items-center justify-between">
             <div>
                 <p class="text-sm font-medium text-gray-600 dark:text-gray-300">{{t .Lang "dashboard.monthly_spend"}}</p>
+                {{if .Stats.ConversionComplete}}
                 <p class="text-3xl font-bold text-primary">{{.CurrencySymbol}}{{printf "%.2f" .Stats.TotalMonthlySpend}}</p>
+                {{else}}
+                {{range $currency, $totals := .Stats.TotalsByCurrency}}{{if $totals.ActiveSubscriptions}}
+                <p class="text-3xl font-bold text-primary">{{printf "%.2f" $totals.TotalMonthlySpend}} {{$currency}}</p>
+                {{end}}{{end}}
+                {{end}}
             </div>
             <div class="w-12 h-12 bg-blue-100 dark:bg-blue-900/50 rounded-full flex items-center justify-center">
                 <svg class="w-6 h-6 text-primary" fill="currentColor" viewBox="0 0 20 20">
@@ -191,7 +197,13 @@
         <div class="flex items-center justify-between">
             <div>
                 <p class="text-sm font-medium text-gray-600 dark:text-gray-300">{{t .Lang "dashboard.annual_spend"}}</p>
+                {{if .Stats.ConversionComplete}}
                 <p class="text-3xl font-bold text-success">{{.CurrencySymbol}}{{printf "%.2f" .Stats.TotalAnnualSpend}}</p>
+                {{else}}
+                {{range $currency, $totals := .Stats.TotalsByCurrency}}{{if $totals.ActiveSubscriptions}}
+                <p class="text-3xl font-bold text-success">{{printf "%.2f" $totals.TotalAnnualSpend}} {{$currency}}</p>
+                {{end}}{{end}}
+                {{end}}
             </div>
             <div class="w-12 h-12 bg-green-100 dark:bg-green-900/50 rounded-full flex items-center justify-center">
                 <svg class="w-6 h-6 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -221,7 +233,15 @@
         <div class="flex items-center justify-between">
             <div>
                 <p class="text-sm font-medium text-gray-600 dark:text-gray-300">{{t .Lang "dashboard.monthly_savings"}}</p>
+                {{if .Stats.ConversionComplete}}
                 <p class="text-3xl font-bold text-danger">{{.CurrencySymbol}}{{printf "%.2f" .Stats.MonthlySaved}}</p>
+                {{else if .Stats.CancelledSubscriptions}}
+                {{range $currency, $totals := .Stats.TotalsByCurrency}}{{if $totals.CancelledSubscriptions}}
+                <p class="text-3xl font-bold text-danger">{{printf "%.2f" $totals.MonthlySaved}} {{$currency}}</p>
+                {{end}}{{end}}
+                {{else}}
+                <p class="text-3xl font-bold text-danger">{{.CurrencySymbol}}0.00</p>
+                {{end}}
                 <p class="text-xs text-gray-500 dark:text-gray-400">{{t .Lang "dashboard.from_cancellations"}}</p>
             </div>
             <div class="w-12 h-12 bg-red-100 dark:bg-red-900/50 rounded-full flex items-center justify-center">
@@ -240,6 +260,7 @@
     
     
     <div class="space-y-4">
+        {{if .Stats.ConversionComplete}}
         {{range $category, $amount := .Stats.CategorySpending}}
         <div class="flex items-center justify-between">
             <div class="flex items-center">
@@ -259,6 +280,26 @@
             <p>{{t .Lang "dashboard.no_category_data"}}</p>
             <p class="text-xs mt-2">{{t .Lang "dashboard.no_category_data_help"}}</p>
         </div>
+        {{end}}
+        {{else}}
+        {{range $category, $amounts := .Stats.CategorySpendingByCurrency}}
+        <div class="flex items-center justify-between">
+            <div class="flex items-center">
+                <div class="w-3 h-3 bg-primary rounded-full mr-3"></div>
+                <span class="text-sm font-medium text-gray-700 dark:text-gray-200">{{$category}}</span>
+            </div>
+            <div class="text-right">
+                {{range $currency, $amount := $amounts}}
+                <div class="text-sm font-medium text-gray-900 dark:text-white">{{printf "%.2f" $amount}} {{$currency}}</div>
+                {{end}}
+            </div>
+        </div>
+        {{else}}
+        <div class="text-center py-8 text-gray-500 dark:text-gray-400">
+            <p>{{t .Lang "dashboard.no_category_data"}}</p>
+            <p class="text-xs mt-2">{{t .Lang "dashboard.no_category_data_help"}}</p>
+        </div>
+        {{end}}
         {{end}}
     </div>
 </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -296,6 +296,9 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
                 </a>
+                {{if .ConversionRateStale}}
+                <p class="text-xs text-gray-500 dark:text-gray-400">Rate from {{.ConversionRateDate.Format "2006-01-02"}}</p>
+                {{end}}
                 {{else}}
                 <p class="text-sm font-medium text-gray-900 dark:text-white">{{.DisplayCurrencySymbol}}{{printf "%.2f" .Cost}}</p>
                 {{end}}

--- a/templates/subscription-form.html
+++ b/templates/subscription-form.html
@@ -92,7 +92,7 @@
             <div>
                 <label for="cost" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{t .Lang "form.cost"}} *</label>
                 <div class="relative">
-                    <span class="absolute left-3 top-2 text-gray-500 dark:text-gray-400">{{.CurrencySymbol}}</span>
+                    <span id="cost-currency-symbol" class="absolute left-3 top-2 text-gray-500 dark:text-gray-400">{{.CurrencySymbol}}</span>
                     <input type="number" id="cost" name="cost" step="0.01" min="0" required
                            value="{{if .Subscription}}{{.Subscription.Cost}}{{end}}"
                            class="w-full pl-8 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition-colors duration-150">
@@ -114,10 +114,10 @@
             <!-- Original Currency -->
             <div>
                 <label for="original_currency" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{{t .Lang "form.currency"}} *</label>
-                <select id="original_currency" name="original_currency" required
+                <select id="original_currency" name="original_currency" required onchange="updateCostCurrencySymbol()"
                         class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 transition-colors duration-150">
                     {{range .Currencies}}
-                    <option value="{{.Code}}" {{if $.Subscription}}{{if eq $.Subscription.OriginalCurrency .Code}}selected{{end}}{{else}}{{if eq .Code "USD"}}selected{{end}}{{end}}>{{.Symbol}} {{.Code}}</option>
+                    <option value="{{.Code}}" data-symbol="{{.Symbol}}" {{if eq $.FormCurrency .Code}}selected{{end}}>{{.Symbol}} {{.Code}}</option>
                     {{end}}
                 </select>
             </div>
@@ -370,6 +370,12 @@ function updateScheduleFields() {
     scheduleInput.value = parts[0];
     intervalInput.value = parts[1] || '1';
     calculateRenewalDate();
+}
+
+function updateCostCurrencySymbol() {
+    const currencySelect = document.getElementById('original_currency');
+    const currencySymbol = document.getElementById('cost-currency-symbol');
+    currencySymbol.textContent = currencySelect.selectedOptions[0].dataset.symbol;
 }
 
 function initScheduleCombo() {

--- a/templates/subscription-list.html
+++ b/templates/subscription-list.html
@@ -159,6 +159,9 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                         </svg>
                     </a>
+                    {{if .ConversionRateStale}}
+                    <div class="text-xs text-gray-500 dark:text-gray-400">Rate from {{.ConversionRateDate.Format "2006-01-02"}}</div>
+                    {{end}}
                     {{else}}
                     <div class="text-sm font-medium text-gray-900 dark:text-white">{{.DisplayCurrencySymbol}}{{printf "%.2f" .Cost}}</div>
                     {{end}}

--- a/templates/subscriptions.html
+++ b/templates/subscriptions.html
@@ -349,8 +349,11 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                             </svg>
                         </a>
+                        {{if .ConversionRateStale}}
+                        <div class="text-xs text-gray-500 dark:text-gray-400">Rate from {{.ConversionRateDate.Format "2006-01-02"}}</div>
+                        {{end}}
                         {{else}}
-                        <div class="text-sm font-medium text-gray-900 dark:text-white">{{$.CurrencySymbol}}{{printf "%.2f" .Cost}}</div>
+                        <div class="text-sm font-medium text-gray-900 dark:text-white">{{.DisplayCurrencySymbol}}{{printf "%.2f" .Cost}}</div>
                         {{end}}
                         {{if .IsShared}}
                         <div class="text-xs text-gray-500 dark:text-gray-400">

--- a/tests/subscription-currency.spec.js
+++ b/tests/subscription-currency.spec.js
@@ -1,0 +1,50 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test('updates the cost prefix and submits the selected currency', async ({ page }) => {
+  let categories = await (await page.request.get('/api/categories')).json();
+  if (categories.length === 0) {
+    const categoryResponse = await page.request.post('/api/categories', {
+      data: { name: `Currency Test ${Date.now()}` },
+    });
+    categories = [await categoryResponse.json()];
+  }
+
+  await page.goto('/subscriptions');
+  await page.locator('header button:has-text("Add"), header button:has-text("Añadir")').first().click();
+  await page.waitForSelector('input[name="name"]');
+
+  const currency = page.locator('select[name="original_currency"]');
+  const costPrefix = page.locator('#cost-currency-symbol');
+
+  await currency.selectOption('SEK');
+  await expect(costPrefix).toHaveText('kr');
+
+  await currency.selectOption('USD');
+  await expect(costPrefix).toHaveText('$');
+
+  const subscriptionName = `USD Currency Test ${Date.now()}`;
+  await page.fill('input[name="name"]', subscriptionName);
+  await page.fill('input[name="cost"]', '9.99');
+  await page.selectOption('select[name="category_id"]', String(categories[0].id));
+  await page.selectOption('select#schedule_combo', 'Monthly_1');
+  await page.selectOption('select[name="status"]', 'Active');
+
+  const createResponse = page.waitForResponse(response =>
+    response.url().endsWith('/api/subscriptions') && response.request().method() === 'POST'
+  );
+  await page.locator('form button[type="submit"]').click();
+  await createResponse;
+  await page.waitForLoadState('networkidle');
+
+  const row = page.locator('tr', { hasText: subscriptionName }).first();
+  await expect(row).toBeVisible();
+  const editButton = row.locator('button[title*="Edit"], button[title*="Editar"], button[title*="Bearbeiten"], button[title*="Bewerken"]');
+  const editPath = await editButton.getAttribute('hx-get');
+  if (!editPath) throw new Error('Edit button is missing its subscription path');
+  await editButton.click();
+  await expect(page.locator('select[name="original_currency"]')).toHaveValue('USD');
+
+  const subscriptionID = editPath.split('/').pop();
+  await page.request.delete(`/api/subscriptions/${subscriptionID}`);
+});


### PR DESCRIPTION
Hey, 

Since I am dealing with a bunch of different (from the default) currencies in my subscriptions I noticed that they don't mix very well. The absolute values are used to do aggregations, foreign currency values are displayed on the calendar with the default currency symbol, etc. Going over that I realized that some changes were also needed for the Fixer.io integration so it's used more evenly throughout. Also I wanted to make sure API calls are lowered to a minimum to be able to stay within the free tier of 100 calls per month as much as possible. No proper lock is implemented so technically there can be more calls made in certain cases I think, but it should be ok as is now.

This is a bit extensive but shouldn't require any data migrations. From my own local tests (with and without a fixer api key, with or without fetched and cached exchange rates) it looks pretty ok.

I tried to keep decisions on changes to a minimum. I understand it is still quite hefty for a PR. Hopefully I kept to the convention of the project and it's not too cumbersome for review.

Here's a not so short list of the changes included here:
- Derive cross-currency rates from cached EUR-based rates, allowing one Fixer snapshot to serve every supported currency pair
- Persist a 24-hour cooldown after each automatic Fixer refresh attempt, including failed attempts, reducing repeated calls across subsequent requests and application restarts
- Fall back to stale cached rates when Fixer is unavailable, its quota is exhausted, or no API key is configured
- Indicate when subscription values use stale cached rates and show the date of those rates
- Convert dashboard and analytics totals into the preferred currency when all required rates are available
- Show totals grouped by original currency when any required rate is missing, avoiding invalid mixed-currency sums
- Hide category percentage bars when currencies cannot be safely combined (I was not really sure what is a good solution here)
- Apply conversion-aware statistics consistently to the dashboard, analytics, stats API, backups, and MCP endpoint
- Display calendar costs in the preferred currency when conversion is available, falling back to the original amount and symbol otherwise
- Sort subscriptions using their converted displayed costs when the required rates are available. When rates are unavailable, group cost sorting by currency and sort numerically within each group
- Remove the obsolete raw SQL category-statistics path replaced by conversion-aware aggregation