### PR TITLE
feat: armv7 build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,7 +65,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/verify-docker-armv7.yml
+++ b/.github/workflows/verify-docker-armv7.yml
@@ -76,7 +76,7 @@ jobs:
           exit 1
 
       - name: Verify root endpoint
-        run: curl -fsSI http://127.0.0.1:18080/
+        run: curl -fsS http://127.0.0.1:18080/ > /dev/null
 
       - name: Show container logs on failure
         if: failure()

--- a/.github/workflows/verify-docker-armv7.yml
+++ b/.github/workflows/verify-docker-armv7.yml
@@ -1,0 +1,87 @@
+name: Verify Docker ARMv7
+
+on:
+  push:
+    branches:
+      - feature/armv7-docker-build
+    paths:
+      - 'Dockerfile'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'templates/**'
+      - 'web/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/docker-publish.yml'
+      - '.github/workflows/verify-docker-armv7.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-armv7:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract version info
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            GIT_TAG="${{ github.ref_name }}"
+          else
+            GIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+          fi
+          GIT_COMMIT=$(git rev-parse --short HEAD)
+          echo "tag=$GIT_TAG" >> $GITHUB_OUTPUT
+          echo "commit=$GIT_COMMIT" >> $GITHUB_OUTPUT
+
+      - name: Build ARMv7 image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm/v7
+          load: true
+          tags: subtrackr:armv7-verify
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            GIT_TAG=${{ steps.version.outputs.tag }}
+            GIT_COMMIT=${{ steps.version.outputs.commit }}
+
+      - name: Start ARMv7 container
+        run: docker run -d --rm --name subtrackr-armv7 -p 18080:8080 subtrackr:armv7-verify
+
+      - name: Wait for health endpoint
+        run: |
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:18080/healthz > /dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          exit 1
+
+      - name: Verify root endpoint
+        run: curl -fsSI http://127.0.0.1:18080/
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker logs subtrackr-armv7
+
+      - name: Stop ARMv7 container
+        if: always()
+        run: docker rm -f subtrackr-armv7 || true

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Themes persist across all pages and are saved per user. Change themes anytime fr
 
 ## 🚀 Quick Start
 
-SubTrackr is available as a multi-platform Docker image supporting both AMD64 and ARM64 architectures (including Apple Silicon).
+SubTrackr is available as a multi-platform Docker image supporting AMD64, ARM64 (including Apple Silicon), and ARMv7 architectures.
 
 **Note:** SubTrackr works fully out-of-the-box with no external dependencies. The Fixer.io API key is completely optional for currency conversion features.
 


### PR DESCRIPTION
Hey! It would be great to run your service on a raspi2. For that, I need a armv7 build. I added the workflow `verify-docker-armv7.yml` to make sure it will work. You can see the result here: https://github.com/DustinOnGithub/subtrackr/actions/runs/32337443548 or run it by yourself. It just builds the service and check against the health check. I will remove the workflow file after you are fine with it, i think we do not need it in main?

Thanks!